### PR TITLE
fix: always open text links in external browser

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ketch-com/ketch-react-native",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Ketch React Native Library",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package/src/KetchServiceProvider/KetchServiceProvider.tsx
+++ b/package/src/KetchServiceProvider/KetchServiceProvider.tsx
@@ -7,8 +7,11 @@ import React, {
   useEffect,
 } from 'react';
 
-import { Platform, NativeModules, View } from 'react-native';
-import WebView, { type WebViewMessageEvent } from 'react-native-webview';
+import { Platform, NativeModules, View, Linking } from 'react-native';
+import WebView, {
+  type WebViewMessageEvent,
+  type WebViewNavigation,
+} from 'react-native-webview';
 
 import type {
   PreferenceExperienceOptions,
@@ -270,6 +273,21 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
           allowFileAccessFromFileURLs
           allowUniversalAccessFromFileURLs
           onMessage={handleMessageReceive}
+          onShouldStartLoadWithRequest={(request: WebViewNavigation) => {
+            /**
+             * Below forces links clicked within the webview (e.g. TOS or Privacy Policy links) to
+             * open in an external web browser. This is the default behavior in Android but not iOS,
+             * and is desirable because opening links in the same webview creates identity issues.
+             */
+            if (
+              request.navigationType === 'click' &&
+              request.url.startsWith('http')
+            ) {
+              Linking.openURL(request.url); // Open link in external browser
+              return false; // Prevent WebView from loading the clicked link
+            }
+            return true; // Otherwise load other links as normal (e.g. API requests)
+          }}
           style={styles.webView}
         />
       </View>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> This adds an event handler to force links clicked within the webview to always open in an external browser on the device (e.g. the safari or chrome app). This is the default behavior on android but not on safari, and is desirable because opening links in the same webview creates identity (and other) issues.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Locally with sample app on ios and android

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://ketch-com.atlassian.net/browse/KD-13514

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
