### PR TITLE
fix(ci): remove artifacts parameter from release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,4 +117,3 @@ jobs:
         uses: conventional-actions/create-release@50cd05b8ea9f2f3f32bbb822706b01ebf2ccce62  # v1
         with:
           tag_name: ${{ steps.version.outputs.version }}
-          artifacts: "*"


### PR DESCRIPTION
## Problem

The release step was failing with:
```
Error: List Artifacts failed: Artifact service responded with 404
```

The workflow tries to attach artifacts to the GitHub release using `artifacts: "*"`, but there are no `actions/upload-artifact` steps in the workflow, so no artifacts exist to attach.

## Solution

Remove the `artifacts` parameter from the create-release step.

## Impact

- ✅ Releases will complete successfully
- ✅ Source code archives (zip/tar.gz) still automatically generated by GitHub
- ✅ No artifacts needed for an npm library (users install via npm)

## Testing

The release step will complete without errors once merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the unused artifacts attachment in the GitHub release workflow to stop failures when no artifacts are uploaded.
> 
> - Delete `artifacts: "*"` from the `Create Release` step in `.github/workflows/ci.yml`
> - Prevents `List Artifacts failed: 404` while keeping npm publishes and GitHub auto-generated source archives unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49f562e5eec923bd152445e62862bbed6e8b936c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->