### PR TITLE
fix: upgrade conventional-actions to node24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Generate next version
         id: version
-        uses: conventional-actions/next-version@e48c1275d221bd29e2c08f8856b91695c0a72db1  # v1
+        uses: conventional-actions/next-version@1b3e4803a0bdf7435ba7bb5ace077445ed54e82a # v1.1.8
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
@@ -114,6 +114,6 @@ jobs:
           npm publish --provenance --ignore-scripts --access public --registry https://registry.npmjs.org/
 
       - name: Create Release
-        uses: conventional-actions/create-release@50cd05b8ea9f2f3f32bbb822706b01ebf2ccce62  # v1
+        uses: conventional-actions/create-release@c025b7306d14a25901b72486f97f3ebe7662a8ed # v1.0.31
         with:
           tag_name: ${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

Upgrade conventional-actions to node24-compatible releases:

- `conventional-actions/next-version` → **v1.1.8** (`1b3e480`)
- `conventional-actions/create-release` → **v1.0.31** (`c025b73`)

Node 20 reaches EOL April 2026 and GitHub is forcing migration to node24 by June 2026.

### Upstream PRs

- https://github.com/conventional-actions/next-version/pull/96
- https://github.com/conventional-actions/create-release/pull/8

## Test plan

- [ ] CI passes on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates pinned GitHub Action versions in the release workflow; behavior should be unchanged aside from upstream action internals.
> 
> **Overview**
> Updates the CI release workflow to use newer `conventional-actions` revisions: `next-version` is bumped to `v1.1.8` and `create-release` to `v1.0.31` (Node 24–compatible builds). No other build/test/publish steps are changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b5dc529046f0c016d60d9bb0da6e26ca92cffac. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->