### PR TITLE
fix(ci): build lib/ before publishing to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,13 @@ jobs:
       - name: Build library
         run: npm run all
 
+      - name: Verify tarball contains lib/
+        run: |
+          npm pack --dry-run 2>&1 | tee /tmp/pack-contents.txt
+          grep -q "lib/commonjs/index\.js" /tmp/pack-contents.txt
+          grep -q "lib/module/index\.js" /tmp/pack-contents.txt
+          grep -q "lib/typescript/src/index\.d\.ts" /tmp/pack-contents.txt
+
   release:
     needs: build
 
@@ -101,6 +108,9 @@ jobs:
 
       - name: Install Dependencies
         run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Build library
+        run: npm run prepare
 
       - name: Publish (pkg.github)
         run: npm publish --provenance --ignore-scripts --access public


### PR DESCRIPTION
## Description of this change

> Fix CI release job that has been publishing tarballs missing the `lib/` directory since v0.10.3, causing MODULE_NOT_FOUND errors for all npm consumers.
>
> - Add `npm run prepare` step to the release job so `lib/` is built before `npm publish` runs
> - Add `Verify tarball contains lib/` step to the build job that asserts `lib/commonjs/index.js`, `lib/module/index.js`, and `lib/typescript/src/index.d.ts` are present in the would-be tarball on every PR



## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Confirmed `@ketch-com/ketch-react-native@0.19.0` (latest published) is missing `lib/` — `node -e "require('@ketch-com/ketch-react-native')"` throws `MODULE_NOT_FOUND` on a clean install
> - Simulated the release runner locally: `npm ci --ignore-scripts && npm run prepare && npm pack --dry-run` — confirmed `lib/commonjs/index.js` and `lib/module/index.js` appear in the tarball listing
> - Verified `npm run prepare` builds all 3 targets (`lib/commonjs`, `lib/module`, `lib/typescript`) successfully

## Related issues


## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

[KD-17356]: https://ketch-com.atlassian.net/browse/KD-17356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: workflow-only changes that ensure build artifacts are produced and included in the package tarball; main failure mode is a CI/release pipeline break rather than runtime behavior changes.
> 
> **Overview**
> Ensures published npm tarballs include the built `lib/` outputs by running `npm run prepare` in the `release` job before `npm publish`.
> 
> Adds a CI guard in the `build` job that runs `npm pack --dry-run` and fails if expected `lib/commonjs`, `lib/module`, and TypeScript `.d.ts` entries are missing from the would-be tarball.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998bce249315ba0d3fba62f9ee1e5d2490ea5ebe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->