### PR TITLE
feat: add native storage bridge

### DIFF
--- a/package/src/KetchServiceProvider/KetchServiceProvider.tsx
+++ b/package/src/KetchServiceProvider/KetchServiceProvider.tsx
@@ -5,6 +5,7 @@ import React, {
   useReducer,
   useCallback,
   useEffect,
+  useMemo,
   type ReactElement,
 } from 'react';
 
@@ -38,11 +39,33 @@ import {
 
 import { KetchServiceContext } from '../context';
 import { Action, reducer } from './reducer';
-import { createOptionsString, savePrivacyToStorage } from '../util';
-import { getIndexHtml, injectCssIntoHtml } from '../assets';
+import {
+  createOptionsString,
+  getWebViewConfigKey,
+  savePrivacyToStorage,
+} from '../util';
+import { getIndexHtml, injectCssIntoHtml, injectWebResourceUrlOverridesIntoHtml, getWebResourceUrlOverridesInjectionScript } from '../assets';
 import styles from './styles';
 import crossPlatformSave from '../util/crossPlatformSave';
+import crossPlatformRead from '../util/crossPlatformRead';
 import wrapSharedPrefences from '../util/wrapSharedPrefences';
+import { KetchHeadless } from '../headless';
+import {
+  trackingAuthorizationStatusString,
+  ATT_LAST_STORAGE_KEY,
+} from '../trackingAuthorization';
+import type {
+  ConsentConfig,
+  ConsentUpdate,
+  FullConfigurationRequest,
+  GetProfileRequest,
+  InvokeRightRequest,
+  PreferenceQRRequest,
+  PutProfileRequest,
+  SubscriptionConfigurationRequest,
+  SubscriptionsRequest,
+  WebReportRequest,
+} from '../headless/headlessTypes';
 
 interface KetchServiceProviderParams extends KetchMobile {
   children: ReactElement;
@@ -83,6 +106,7 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
   forcePreferenceExperience = false,
   preferenceExperienceOptions = {},
   preferenceStorage,
+  webResourceUrlOverrides,
   autoLoad = true,
   children,
   onEnvironmentUpdated,
@@ -93,6 +117,7 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
   onPrivacyProtocolUpdated,
   onHideExperience,
   onHasShownExperience,
+  onNativeStoragePut,
   onError,
   cssOverride: initialCssOverride,
 }) => {
@@ -100,7 +125,14 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
   const [isVisible, setIsVisible] = useState(false);
   const [isServiceReady, setIsServiceReady] = useState(false);
   const [shouldLoadWebView, setShouldLoadWebView] = useState(autoLoad);
-  const [webViewKey, setWebViewKey] = useState(0);
+  const [webViewReloadNonce, setWebViewReloadNonce] = useState(0);
+  const [resolvedKetchAtt, setResolvedKetchAtt] = useState<string | undefined>(
+    undefined
+  );
+  const [resolvedKetchAttPrev, setResolvedKetchAttPrev] = useState<
+    string | undefined
+  >(undefined);
+  const [isAttReady, setIsAttReady] = useState(Platform.OS !== 'ios');
 
   // CSS override state
   const [cssOverrideState, setCssOverrideState] = useState<string | undefined>(
@@ -150,6 +182,7 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
     age,
     ageLower,
     ageUpper,
+    webResourceUrlOverrides,
     onEnvironmentUpdated,
     onRegionUpdated,
     onJurisdictionUpdated,
@@ -158,20 +191,156 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
     onPrivacyProtocolUpdated,
     onHideExperience,
     onHasShownExperience,
+    onNativeStoragePut,
     onError,
   });
+
+  const webViewParameters = useMemo(() => {
+    const att = parameters.ketchAtt ?? resolvedKetchAtt;
+    const attPrev = parameters.ketchAttPrev ?? resolvedKetchAttPrev;
+    const withAtt = att ? { ...parameters, ketchAtt: att } : parameters;
+    return attPrev ? { ...withAtt, ketchAttPrev: attPrev } : withAtt;
+  }, [parameters, resolvedKetchAtt, resolvedKetchAttPrev]);
+
+  const webViewMountKey = useMemo(
+    () =>
+      `${getWebViewConfigKey(webViewParameters)}|${cssOverrideState ?? ''}|${webViewReloadNonce}`,
+    [webViewParameters, cssOverrideState, webViewReloadNonce]
+  );
+
+  const webResourceUrlOverrideScript = useMemo(
+    () => getWebResourceUrlOverridesInjectionScript(webViewParameters.webResourceUrlOverrides),
+    [webViewParameters.webResourceUrlOverrides]
+  );
+
+  useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      setIsAttReady(true);
+      return;
+    }
+
+    let cancelled = false;
+    setIsAttReady(false);
+
+    const resolveAtt = async () => {
+      const attPrev =
+        Platform.OS === 'ios'
+          ? ((await crossPlatformRead(ATT_LAST_STORAGE_KEY)) ?? 'notDetermined')
+          : undefined;
+
+      if (parameters.ketchAtt) {
+        if (!cancelled) {
+          setResolvedKetchAttPrev(attPrev);
+          setResolvedKetchAtt(parameters.ketchAtt);
+          setIsAttReady(true);
+        }
+        return;
+      }
+
+      const att = await trackingAuthorizationStatusString();
+      if (!cancelled) {
+        setResolvedKetchAttPrev(attPrev);
+        setResolvedKetchAtt(att ?? undefined);
+        setIsAttReady(true);
+      }
+    };
+
+    resolveAtt().catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [parameters.ketchAtt, webViewMountKey]);
+
+  const headlessApi = useMemo(
+    () => new KetchHeadless({ dataCenter: parameters.dataCenter }),
+    [parameters.dataCenter]
+  );
+
+  const fetchLocation = useCallback(
+    () => headlessApi.fetchLocation(),
+    [headlessApi]
+  );
+
+  const fetchBootstrapConfiguration = useCallback(
+    () =>
+      headlessApi.fetchBootstrapConfiguration(
+        parameters.organizationCode,
+        parameters.propertyCode
+      ),
+    [headlessApi, parameters.organizationCode, parameters.propertyCode]
+  );
+
+  const fetchFullConfiguration = useCallback(
+    (request: FullConfigurationRequest) =>
+      headlessApi.fetchFullConfiguration(request),
+    [headlessApi]
+  );
+
+  const fetchConsent = useCallback(
+    (config: ConsentConfig) => headlessApi.fetchConsent(config),
+    [headlessApi]
+  );
+
+  const fetchProtocols = useCallback(
+    (config: ConsentConfig) => headlessApi.fetchProtocols(config),
+    [headlessApi]
+  );
+
+  const setConsentOnServer = useCallback(
+    (update: ConsentUpdate) => headlessApi.setConsentOnServer(update),
+    [headlessApi]
+  );
+
+  const invokeRight = useCallback(
+    (request: InvokeRightRequest) => headlessApi.invokeRight(request),
+    [headlessApi]
+  );
+
+  const getProfile = useCallback(
+    (request: GetProfileRequest) => headlessApi.getProfile(request),
+    [headlessApi]
+  );
+
+  const putProfile = useCallback(
+    (request: PutProfileRequest) => headlessApi.putProfile(request),
+    [headlessApi]
+  );
+
+  const getSubscriptions = useCallback(
+    (request: SubscriptionsRequest) => headlessApi.getSubscriptions(request),
+    [headlessApi]
+  );
+
+  const setSubscriptions = useCallback(
+    (request: SubscriptionsRequest) => headlessApi.setSubscriptions(request),
+    [headlessApi]
+  );
+
+  const fetchSubscriptionsConfiguration = useCallback(
+    (request: SubscriptionConfigurationRequest) =>
+      headlessApi.fetchSubscriptionsConfiguration(request),
+    [headlessApi]
+  );
+
+  const preferenceQRUrl = useCallback(
+    (request: PreferenceQRRequest) => headlessApi.preferenceQRUrl(request),
+    [headlessApi]
+  );
+
+  const webReport = useCallback(
+    (channel: string, request: WebReportRequest) =>
+      headlessApi.webReport(channel, request),
+    [headlessApi]
+  );
 
   /**
    * Load or reload the webview
    */
   const load = useCallback(() => {
-    if (shouldLoadWebView && webViewRef.current) {
-      // This forces the WebView to remount and reload the page. We cannot use
-      // webViewRef.current.reload() because parameters are lost and there are issues with
-      // this method on android (https://github.com/react-native-webview/react-native-webview/issues/2826).
-      setWebViewKey((prev) => prev + 1);
+    if (shouldLoadWebView) {
+      // Remount — reload() drops parameters on Android (react-native-webview#2826).
+      setWebViewReloadNonce((prev) => prev + 1);
     } else {
-      // Initial load
       setShouldLoadWebView(true);
     }
   }, [shouldLoadWebView]);
@@ -282,17 +451,16 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
         '[Ketch] CSS override rejected: must not contain HTML tags!'
       );
       setCssOverrideState(undefined);
-      setWebViewKey((prev) => prev + 1);
+      setWebViewReloadNonce((prev) => prev + 1);
       return;
     }
     if (!isWithin1kb(css)) {
       console.warn('[Ketch] CSS override rejected: CSS too long (>1kb limit)!');
       setCssOverrideState(undefined);
-      setWebViewKey((prev) => prev + 1);
+      setWebViewReloadNonce((prev) => prev + 1);
       return;
     }
     setCssOverrideState(css);
-    setWebViewKey((prev) => prev + 1);
   }, []);
 
   const storePreference = preferenceStorage
@@ -413,6 +581,24 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
         onError?.(data.data);
         break;
 
+      case EventName.openAppSettings:
+        if (Platform.OS === 'ios') {
+          Linking.openSettings().catch((error) => {
+            console.warn('Failed to open app settings:', error);
+          });
+        }
+        break;
+
+      case EventName.nativeStoragePut: {
+        const payload = JSON.parse(data.data) as { key: string; value: string };
+        if (!payload.key) {
+          break;
+        }
+        crossPlatformSave(payload.key, payload.value).catch(() => {});
+        parameters.onNativeStoragePut?.(payload.key, payload.value);
+        break;
+      }
+
       default:
         break;
     }
@@ -435,23 +621,41 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
         updateParameters,
         load,
         setCssOverride,
+        fetchLocation,
+        fetchBootstrapConfiguration,
+        fetchFullConfiguration,
+        fetchConsent,
+        fetchProtocols,
+        setConsentOnServer,
+        invokeRight,
+        getProfile,
+        putProfile,
+        getSubscriptions,
+        setSubscriptions,
+        fetchSubscriptionsConfiguration,
+        preferenceQRUrl,
+        webReport,
       }}
     >
       {children}
-      {shouldLoadWebView && (
+      {shouldLoadWebView && isAttReady && (
         <View
           style={[styles.container, isVisible ? styles.shown : styles.hidden]}
         >
           <WebView
-            key={webViewKey}
+            key={webViewMountKey}
             ref={webViewRef}
             source={{
               html: injectCssIntoHtml(
-                getIndexHtml(parameters),
+                injectWebResourceUrlOverridesIntoHtml(
+                  getIndexHtml(webViewParameters),
+                  webViewParameters.webResourceUrlOverrides
+                ),
                 cssOverrideState
               ),
               baseUrl: 'http://localhost',
             }}
+            injectedJavaScriptBeforeContentLoaded={webResourceUrlOverrideScript}
             injectedJavaScript={
               Platform.OS === 'android' ? injectedJavaScript : undefined
             }

--- a/package/src/enums/index.ts
+++ b/package/src/enums/index.ts
@@ -46,6 +46,8 @@ export enum EventName {
   updateTCF = 'tcf_updated_data',
   updateGPP = 'gpp_updated_data',
   error = 'error',
+  openAppSettings = 'openAppSettings',
+  nativeStoragePut = 'nativeStoragePut',
 }
 
 export enum OnHideExperienceArgument {
@@ -68,7 +70,7 @@ export enum OnHideExperienceArgument {
   /**
    * Experience was closed without setting consent (preference experience only)
    */
-  closeWithoutSettingsConsent = 'closeWithoutSettingsConsent',
+  closeWithoutSettingConsent = 'closeWithoutSettingConsent',
   /**
    * Experience was closed due to subscriptions being set
    */

--- a/package/src/types/index.ts
+++ b/package/src/types/index.ts
@@ -6,6 +6,21 @@ import {
   type PreferenceTab,
   type PrivacyProtocol,
 } from '../enums';
+import type {
+  ConsentConfig,
+  ConsentUpdate,
+  FullConfigurationRequest,
+  GetProfileRequest,
+  GetProfileResponse,
+  InvokeRightRequest,
+  LocationResponse,
+  PreferenceQRRequest,
+  PutProfileRequest,
+  SubscriptionConfigurationRequest,
+  SubscriptionsRequest,
+  SubscriptionsResponse,
+  WebReportRequest,
+} from '../headless/headlessTypes';
 
 /**
  * Consent object
@@ -39,6 +54,9 @@ export type CommonExperienceOptions = Pick<
   | 'age'
   | 'ageLower'
   | 'ageUpper'
+  | 'ketchAtt'
+  | 'ketchAttPrev'
+  | 'webResourceUrlOverrides'
 > & {
   // This is separate because we don't want to add ketch_show to the KetchMobile type
   // which is used for the KetchServiceProvider parameters
@@ -141,6 +159,21 @@ export interface KetchMobile {
   ageUpper?: number;
 
   /**
+   * iOS ATT status for WebView (`ketch_att`). When omitted, resolved automatically on iOS.
+   */
+  ketchAtt?: string;
+
+  /**
+   * Previous iOS ATT status for WebView (`ketch_att_prev`). When omitted, resolved from native storage on iOS.
+   */
+  ketchAttPrev?: string;
+
+  /**
+   * Exact-match WebView resource URL replacements (e.g. UAT tag scripts → local dev server).
+   */
+  webResourceUrlOverrides?: Record<string, string>;
+
+  /**
    * Force show the consent experience initially
    */
   forceConsentExperience?: boolean;
@@ -216,6 +249,11 @@ export interface KetchMobile {
    * Experience has shown listener
    */
   onHasShownExperience?: () => void;
+
+  /**
+   * Native storage write from ketch-tag (`nativeStoragePut` event).
+   */
+  onNativeStoragePut?: (key: string, value: string) => void;
 }
 
 export interface KetchService {
@@ -256,4 +294,52 @@ export interface KetchService {
    * Will ignore if string contains any HTML tags or exceeds 1kb.
    */
   setCssOverride?: (css: string) => void;
+
+  /** GeoIP / jurisdiction hint (`GET /ip`). Pre-WebView headless API. */
+  fetchLocation?: () => Promise<LocationResponse>;
+
+  /** Minimal config (`GET .../boot.json`). */
+  fetchBootstrapConfiguration?: () => Promise<Record<string, unknown>>;
+
+  /** Full config with optional env / jurisdiction / language and hash query param. */
+  fetchFullConfiguration?: (
+    request: FullConfigurationRequest
+  ) => Promise<Record<string, unknown>>;
+
+  /** Server consent including `protocols`. Does not read WebView cache — use [getConsent]. */
+  fetchConsent?: (config: ConsentConfig) => Promise<Consent>;
+
+  /** Protocol strings only (same CDN endpoint as fetchConsent). */
+  fetchProtocols?: (config: ConsentConfig) => Promise<Consent>;
+
+  /** Updates consent on the CDN; returns server-computed `protocols`. */
+  setConsentOnServer?: (update: ConsentUpdate) => Promise<Consent>;
+
+  /** Invokes a data subject right (`POST .../rights/{org}/invoke`). */
+  invokeRight?: (request: InvokeRightRequest) => Promise<void>;
+
+  /** Gets profile preferences (`POST .../profile/{org}/get`). */
+  getProfile?: (request: GetProfileRequest) => Promise<GetProfileResponse>;
+
+  /** Updates profile preferences (`POST .../profile/{org}/put`). */
+  putProfile?: (request: PutProfileRequest) => Promise<void>;
+
+  /** Gets subscription topics/controls (`POST .../subscriptions/{org}/get`). */
+  getSubscriptions?: (
+    request: SubscriptionsRequest
+  ) => Promise<SubscriptionsResponse>;
+
+  /** Updates subscription topics/controls (`POST .../subscriptions/{org}/update`). */
+  setSubscriptions?: (request: SubscriptionsRequest) => Promise<void>;
+
+  /** Subscriptions tab config (`GET .../subscriptions.json`). */
+  fetchSubscriptionsConfiguration?: (
+    request: SubscriptionConfigurationRequest
+  ) => Promise<Record<string, unknown>>;
+
+  /** Builds preferences QR image URL (no HTTP). */
+  preferenceQRUrl?: (request: PreferenceQRRequest) => string;
+
+  /** Telemetry upload (`POST /report/{channel}`). */
+  webReport?: (channel: string, request: WebReportRequest) => Promise<void>;
 }

--- a/package/src/util/helpers.ts
+++ b/package/src/util/helpers.ts
@@ -59,6 +59,9 @@ export const createUrlParamsObject = (parameters: CommonExperienceOptions) => {
     ketch_age?: string;
     ketch_age_lower?: string;
     ketch_age_upper?: string;
+    ketch_att?: string;
+    ketch_att_prev?: string;
+    webResourceUrlOverrides?: Record<string, string>;
   } = {
     organizationCode: parameters.organizationCode,
     propertyCode: parameters.propertyCode,
@@ -118,7 +121,27 @@ export const createUrlParamsObject = (parameters: CommonExperienceOptions) => {
         result.ketch_age_upper = String(Math.floor(val));
       }
     }
+
+    if (key === 'ketchAtt' && parameters.ketchAtt) {
+      result.ketch_att = parameters.ketchAtt;
+    }
+
+    if (key === 'ketchAttPrev' && parameters.ketchAttPrev) {
+      result.ketch_att_prev = parameters.ketchAttPrev;
+    }
+
+    if (
+      key === 'webResourceUrlOverrides' &&
+      parameters.webResourceUrlOverrides &&
+      Object.keys(parameters.webResourceUrlOverrides).length > 0
+    ) {
+      result.webResourceUrlOverrides = parameters.webResourceUrlOverrides;
+    }
   }
 
   return result;
 };
+
+/** Stable key for WebView remounts when init HTML would change. */
+export const getWebViewConfigKey = (parameters: CommonExperienceOptions) =>
+  JSON.stringify(createUrlParamsObject(parameters));


### PR DESCRIPTION
## Description of this change

KetchServiceProvider nativeStoragePut handling, types/enums/helpers.

Stack base (slice 1/3 replacing #119).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

helpers.test.ts in headless slice; bridge covered by provider changes.

## Related issues

Refs partial stack replacing #119.

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> WebView message handlers persist arbitrary keys to native storage and WebView load timing depends on ATT resolution; the hide-experience enum rename may break apps comparing the old string literal.
> 
> **Overview**
> Expands **KetchServiceProvider** beyond the WebView UI: ketch-tag can drive **native storage** (`nativeStoragePut` → `crossPlatformSave` + optional `onNativeStoragePut`), open **iOS Settings** (`openAppSettings`), and the provider exposes a full set of **headless** consent/config/profile/subscription helpers on context via `KetchHeadless`.
> 
> WebView startup is reworked: **iOS ATT** (`ketch_att` / `ketch_att_prev`) is resolved (or taken from props) before mount; init HTML uses **`webResourceUrlOverrides`** (injected in HTML and `injectedJavaScriptBeforeContentLoaded`); remounts use a stable **`getWebViewConfigKey`**-based key plus a reload nonce instead of a simple counter.
> 
> Types/helpers gain **`ketchAtt`**, **`ketchAttPrev`**, and **`webResourceUrlOverrides`** in URL param building. **`OnHideExperienceArgument.closeWithoutSettingsConsent`** is renamed to **`closeWithoutSettingConsent`** (string value change for integrators).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce333a148184d80c8c1c947b80705bfcbeab8f9f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->