### PR TITLE
feat: add headless consent API

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -6,19 +6,115 @@
  */
 
 import React from 'react';
+import {Platform} from 'react-native';
 
-import {KetchServiceProvider} from '@ketch-com/ketch-react-native';
-import Main from './Main';
+import {
+  KetchDataCenter,
+  KetchServiceProvider,
+  PrivacyProtocol,
+  type Consent,
+} from '@ketch-com/ketch-react-native';
+import Main, {DashboardProvider, useDashboard, formatConsent} from './Main';
+
+/** Flip ENABLED to redirect UAT tag script URLs to local dev servers. */
+const DEV_URL_OVERRIDES_ENABLED = true;
+
+const localKetchSdk: Record<string, string> = {
+  'https://cdn.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js':
+    'http://localhost:9000/ketch-sdk.js',
+  'https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js':
+    'http://localhost:9000/ketch-sdk.js',
+  'ketch-sdk.js': 'http://localhost:9000/ketch-sdk.js',
+};
+
+const forSimulator = localKetchSdk;
+const forAndroidEmulator = localKetchSdk;
+
+function AppWithCallbacks(): React.JSX.Element {
+  const {appendLog, updateDashboard} = useDashboard();
+
+  return (
+    <KetchServiceProvider
+      organizationCode="ethansch061226"
+      propertyCode="website_smart_tag"
+      dataCenter={KetchDataCenter.UAT}
+      identities={{email: 'test-123-1@gmail.com'}}
+      autoLoad={false}
+      webResourceUrlOverrides={
+        DEV_URL_OVERRIDES_ENABLED
+          ? Platform.OS === 'android'
+            ? forAndroidEmulator
+            : forSimulator
+          : undefined
+      }
+      onEnvironmentUpdated={environment => {
+        updateDashboard({environment});
+        appendLog(`onEnvironmentUpdated: ${environment}`);
+      }}
+      onRegionUpdated={region => {
+        updateDashboard({region});
+        appendLog(`onRegionUpdated: ${region}`);
+      }}
+      onJurisdictionUpdated={jurisdiction => {
+        updateDashboard({jurisdiction});
+        appendLog(`onJurisdictionUpdated: ${jurisdiction}`);
+      }}
+      onIdentitiesUpdated={identities => {
+        appendLog(`onIdentitiesUpdated: ${JSON.stringify(identities)}`);
+      }}
+      onConsentUpdated={(consent: Consent) => {
+        const summary = formatConsent(consent);
+        updateDashboard({consent: summary});
+        appendLog(`onConsentUpdated: ${summary}`);
+        console.log('[KetchSample] onConsentUpdated:', summary);
+      }}
+      onPrivacyProtocolUpdated={(protocol, values) => {
+        const text = JSON.stringify(values);
+        if (protocol === PrivacyProtocol.USPrivacy) {
+          updateDashboard({usPrivacy: text});
+        } else if (protocol === PrivacyProtocol.TCF) {
+          updateDashboard({tcf: text});
+        } else if (protocol === PrivacyProtocol.GPP) {
+          updateDashboard({gpp: text});
+        }
+        appendLog(`onPrivacyProtocolUpdated: ${protocol}`);
+      }}
+      onHasShownExperience={() => {
+        updateDashboard({
+          experienceVisibility: 'shown',
+          webViewVisible: 'visible',
+        });
+        appendLog('onHasShownExperience');
+      }}
+      onHideExperience={reason => {
+        updateDashboard({
+          experienceVisibility: 'dismissed',
+          dismissReason: String(reason),
+          webViewVisible: 'hidden',
+        });
+        appendLog(`onHideExperience: ${reason}`);
+      }}
+      onError={errorMessage => {
+        updateDashboard({
+          loadState: 'error',
+          initState: 'Error',
+          statusText: `Error: ${errorMessage}`,
+        });
+        appendLog(`error: ${errorMessage}`);
+      }}
+      onNativeStoragePut={(key, value) => {
+        appendLog(`onNativeStoragePut: ${key}=${value}`);
+      }}>
+      <Main />
+    </KetchServiceProvider>
+  );
+}
 
 function App(): React.JSX.Element {
   return (
-    <KetchServiceProvider
-      organizationCode="ketch_samples"
-      propertyCode="react_native_sample_app"
-      identities={{email: 'test-123-1@gmail.com'}}>
-      {/* Main.tsx is the content of your app. */}
-      <Main />
-    </KetchServiceProvider>
+    <DashboardProvider>
+      <AppWithCallbacks />
+    </DashboardProvider>
   );
 }
 

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-# Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
-# bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'cocoapods', '~> 1.16'
+gem 'activesupport', '~> 7.2'
+gem 'nkf'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,27 +1,33 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.7)
+    CFPropertyList (3.0.8)
+    activesupport (7.2.3.1)
       base64
-      nkf
-      rexml
-    activesupport (7.0.8.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
-    base64 (0.2.0)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.16.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.16.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -35,8 +41,8 @@ GEM
       molinillo (~> 0.8.0)
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
-      xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+      xcodeproj (>= 1.27.0, < 2.0)
+    cocoapods-core (1.16.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -56,48 +62,103 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    drb (2.2.3)
     escape (0.0.4)
-    ethon (0.16.0)
+    ethon (0.18.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
+      logger
+    ffi (1.17.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    httpclient (2.8.3)
-    i18n (1.14.4)
+    httpclient (2.9.0)
+      mutex_m
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    json (2.7.1)
-    minitest (5.22.3)
+    json (2.19.9)
+    logger (1.7.0)
+    minitest (5.27.0)
     molinillo (0.8.0)
-    nanaimo (0.3.0)
+    mutex_m (0.3.0)
+    nanaimo (0.4.0)
     nap (1.1.0)
     netrc (0.11.0)
-    nkf (0.2.0)
+    nkf (0.3.0)
     public_suffix (4.0.7)
-    rexml (3.4.2)
+    rexml (3.4.4)
     ruby-macho (2.5.1)
-    typhoeus (1.4.1)
-      ethon (>= 0.9.0)
+    securerandom (0.4.1)
+    typhoeus (1.6.0)
+      ethon (>= 0.18.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.25.0)
+    xcodeproj (1.27.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.3.0)
-      rexml (>= 3.3.2, < 4.0)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.5, < 7.1.0)
-  cocoapods (>= 1.13, < 1.15)
+  activesupport (~> 7.2)
+  cocoapods (~> 1.16)
+  nkf
+
+CHECKSUMS
+  CFPropertyList (3.0.8) sha256=2c99d0d980536d3d7ab252f7bd59ac8be50fbdd1ff487c98c949bb66bb114261
+  activesupport (7.2.3.1) sha256=11ebed516a43a0bb47346227a35ebae4d9427465a7c9eb197a03d5c8d283cb34
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  algoliasearch (1.27.5) sha256=26c1cddf3c2ec4bd60c148389e42702c98fdac862881dc6b07a4c0b89ffec853
+  atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  benchmark (0.5.0) sha256=465df122341aedcb81a2a24b4d3bd19b6c67c1530713fd533f3ff034e419236c
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  claide (1.1.0) sha256=6d3c5c089dde904d96aa30e73306d0d4bd444b1accb9b3125ce14a3c0183f82e
+  cocoapods (1.16.2) sha256=0ff1c860f32df3db8b16df09b58da1a6bb2a12fe55f6d5e8be994a74fadd1e5e
+  cocoapods-core (1.16.2) sha256=4bb1b5c420691e60cf36fa227dec6bc48c096c34c97bb7aa512ea7f3246fc12b
+  cocoapods-deintegrate (1.0.5) sha256=517c2a448ef563afe99b6e7668704c27f5de9e02715a88ee9de6974dc1b3f6a2
+  cocoapods-downloader (2.1) sha256=bb6ebe1b3966dc4055de54f7a28b773485ac724fdf575d9bee2212d235e7b6d1
+  cocoapods-plugins (1.0.0) sha256=725d17ce90b52f862e73476623fd91441b4430b742d8a071000831efb440ca9a
+  cocoapods-search (1.0.1) sha256=1b133b0e6719ed439bd840e84a1828cca46425ab73a11eff5e096c3b2df05589
+  cocoapods-trunk (1.6.0) sha256=5f5bda8c172afead48fa2d43a718cf534b1313c367ba1194cebdeb9bfee9ed31
+  cocoapods-try (1.2.0) sha256=145b946c6e7747ed0301d975165157951153d27469e6b2763c83e25c84b9defe
+  colored2 (3.1.2) sha256=b13c2bd7eeae2cf7356a62501d398e72fde78780bd26aec6a979578293c28b4a
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  escape (0.0.4) sha256=e49f44ae2b4f47c6a3abd544ae77fe4157802794e32f19b8e773cbc4dcec4169
+  ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
+  ffi (1.17.4) sha256=bcd1642e06f0d16fc9e09ac6d49c3a7298b9789bcb58127302f934e437d60acf
+  fourflusher (2.3.1) sha256=1b3de61c7c791b6a4e64f31e3719eb25203d151746bb519a0292bff1065ccaa9
+  fuzzy_match (2.0.4) sha256=b5de4f95816589c5b5c3ad13770c0af539b75131c158135b3f3bbba75d0cfca5
+  gh_inspector (1.1.3) sha256=04cca7171b87164e053aa43147971d3b7f500fcb58177698886b48a9fc4a1939
+  httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  molinillo (0.8.0) sha256=efbff2716324e2a30bccd3eba1ff3a735f4d5d53ffddbc6a2f32c0ca9433045d
+  mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
+  nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
+  nap (1.1.0) sha256=949691660f9d041d75be611bb2a8d2fd559c467537deac241f4097d9b5eea576
+  netrc (0.11.0) sha256=de1ce33da8c99ab1d97871726cba75151113f117146becbe45aa85cb3dabee3f
+  nkf (0.3.0) sha256=357a8dbeba38b727b75930f665146546076a394a1c243faf634ff176e3588895
+  public_suffix (4.0.7) sha256=8be161e2421f8d45b0098c042c06486789731ea93dc3a896d30554ee38b573b8
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  ruby-macho (2.5.1) sha256=9075e52e0f9270b552a90b24fcc6219ad149b0d15eae1bc364ecd0ac8984f5c9
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  xcodeproj (1.27.0) sha256=8cc7a73b4505c227deab044dce118ede787041c702bc47636856a2e566f854d3
 
 RUBY VERSION
-   ruby 3.3.0p0
+  ruby 4.0.1
 
 BUNDLED WITH
-   2.5.4
+  4.0.3

--- a/example/Main.tsx
+++ b/example/Main.tsx
@@ -5,17 +5,164 @@
  * @format
  */
 
-import React, {useState} from 'react';
+import React, {createContext, useCallback, useContext, useMemo, useState} from 'react';
+import type {Consent} from '@ketch-com/ketch-react-native';
+
+export interface DashboardState {
+  initState: string;
+  statusText: string;
+  loadState: string;
+  experienceVisibility: string;
+  dismissReason: string;
+  webViewVisible: string;
+  environment: string;
+  jurisdiction: string;
+  region: string;
+  consent: string;
+  usPrivacy: string;
+  tcf: string;
+  gpp: string;
+  attStatus: string;
+  ketchAtt: string;
+  ketchAttPrev: string;
+  headlessLocationResult: string;
+  headlessBootstrapResult: string;
+  headlessConsentResult: string;
+  eventLog: string[];
+}
+
+const initialState: DashboardState = {
+  initState: 'Initialized',
+  statusText: 'Ketch initialized',
+  loadState: 'idle',
+  experienceVisibility: 'hidden',
+  dismissReason: '—',
+  webViewVisible: 'unknown',
+  environment: 'Not set',
+  jurisdiction: 'Not set',
+  region: 'Not set',
+  consent: 'Not set',
+  usPrivacy: 'Not set',
+  tcf: 'Not set',
+  gpp: 'Not set',
+  attStatus: 'N/A',
+  ketchAtt: '—',
+  ketchAttPrev: '—',
+  headlessLocationResult: '—',
+  headlessBootstrapResult: '—',
+  headlessConsentResult: '—',
+  eventLog: [],
+};
+
+interface DashboardContextValue {
+  dashboard: DashboardState;
+  appendLog: (message: string) => void;
+  setStatus: (message: string) => void;
+  updateDashboard: (patch: Partial<DashboardState>) => void;
+}
+
+const DashboardContext = createContext<DashboardContextValue | null>(null);
+
+function timestamp(): string {
+  const now = new Date();
+  return now.toLocaleTimeString('en-US', {hour12: false});
+}
+
+export function DashboardProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
+  const [dashboard, setDashboard] = useState<DashboardState>(initialState);
+
+  const appendLog = useCallback((message: string) => {
+    setDashboard(prev => {
+      const line = `[${timestamp()}] ${message}`;
+      const eventLog = [...prev.eventLog, line].slice(-50);
+      return {...prev, eventLog};
+    });
+  }, []);
+
+  const setStatus = useCallback(
+    (message: string) => {
+      appendLog(message);
+      setDashboard(prev => ({...prev, statusText: message}));
+    },
+    [appendLog],
+  );
+
+  const updateDashboard = useCallback((patch: Partial<DashboardState>) => {
+    setDashboard(prev => ({...prev, ...patch}));
+  }, []);
+
+  const value = useMemo(
+    () => ({dashboard, appendLog, setStatus, updateDashboard}),
+    [dashboard, appendLog, setStatus, updateDashboard],
+  );
+
+  return (
+    <DashboardContext.Provider value={value}>{children}</DashboardContext.Provider>
+  );
+}
+
+export function useDashboard(): DashboardContextValue {
+  const ctx = useContext(DashboardContext);
+  if (!ctx) {
+    throw new Error('useDashboard must be used within DashboardProvider');
+  }
+  return ctx;
+}
+
+export function truncate(value: string, max = 80): string {
+  return value.length <= max ? value : `${value.slice(0, max)}…`;
+}
+
+
+export function formatConsent(consent: Consent): string {
+  const parts: string[] = [];
+
+  if (consent.purposes) {
+    const entries = Object.entries(consent.purposes);
+    const allowed = entries.filter(([, value]) => value).map(([key]) => key).sort();
+    const denied = entries.filter(([, value]) => !value).map(([key]) => key).sort();
+    parts.push(
+      `purposes(${entries.length}) allowed=[${allowed.join(',')}] denied=[${denied.join(',')}]`,
+    );
+  } else {
+    parts.push('purposes=undefined');
+  }
+
+  if (consent.vendors?.length) {
+    parts.push(`vendors(${consent.vendors.length})=[${[...consent.vendors].sort().join(',')}]`);
+  }
+
+  if (consent.protocols && Object.keys(consent.protocols).length > 0) {
+    const protocolSummary = Object.entries(consent.protocols)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, value]) => `${key}=${value}`)
+      .join(', ');
+    parts.push(`protocols={${protocolSummary}}`);
+  }
+
+  return parts.join('; ');
+}
+
+export function formatAttState(current: string, previous: string): string {
+  return `ketch_att=${current} ketch_att_prev=${previous}`;
+}
+
+import React, {useEffect, useState} from 'react';
 import {
   Button,
   Keyboard,
   NativeSyntheticEvent,
+  Platform,
   SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
+  Text,
   TextInputEndEditingEventData,
-  useColorScheme,
   View,
 } from 'react-native';
 
@@ -28,6 +175,9 @@ import {
   useKetchService,
   KetchDataCenter,
   PreferenceTab,
+  requestTrackingAuthorization,
+  trackingAuthorizationStatusString,
+  type ConsentConfig,
 } from '@ketch-com/ketch-react-native';
 import DefaultPreference from 'react-native-default-preference';
 
@@ -42,23 +192,88 @@ const PREFERENCE_TABS = Object.values(PreferenceTab).map(preferenceTab => ({
   label: preferenceTabLabels[preferenceTab],
 }));
 
+function consentConfigFromConfiguration(options: {
+  configuration: Record<string, unknown>;
+  identities: Record<string, string>;
+  organizationCode: string;
+  propertyCode: string;
+  environmentCode: string;
+}): ConsentConfig {
+  const {
+    configuration,
+    identities,
+    organizationCode,
+    propertyCode,
+    environmentCode,
+  } = options;
+  const jurisdictionMap = configuration.jurisdiction;
+  let jurisdiction = 'us';
+  if (jurisdictionMap && typeof jurisdictionMap === 'object') {
+    const map = jurisdictionMap as Record<string, unknown>;
+    jurisdiction = String(
+      map.code ?? map.defaultJurisdictionCode ?? jurisdiction,
+    );
+  }
+  const purposesList = configuration.purposes;
+  const purposes: ConsentConfig['purposes'] = {};
+  if (Array.isArray(purposesList)) {
+    for (const entry of purposesList) {
+      if (entry && typeof entry === 'object') {
+        const purpose = entry as Record<string, unknown>;
+        const code = purpose.code?.toString();
+        const legalBasis = purpose.legalBasisCode?.toString();
+        if (code && legalBasis) {
+          purposes[code] = {legalBasisCode: legalBasis};
+        }
+      }
+    }
+  }
+  if (Object.keys(purposes).length === 0) {
+    throw new Error('Configuration returned no purposes');
+  }
+  return {
+    organizationCode,
+    propertyCode,
+    environmentCode,
+    jurisdictionCode: jurisdiction,
+    identities,
+    purposes,
+  };
+}
+
+function DashboardRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}): React.JSX.Element {
+  return (
+    <View style={styles.dashboardRow}>
+      <Text style={styles.dashboardLabel}>{label}:</Text>
+      <Text style={styles.dashboardValue}>{value}</Text>
+    </View>
+  );
+}
+
 function Main(): React.JSX.Element {
   const ketch = useKetchService();
-  const [selectedRegion, setSelectedRegion] = useState(KetchDataCenter.US);
+  const {dashboard, appendLog, setStatus, updateDashboard} = useDashboard();
+  const [selectedRegion, setSelectedRegion] = useState(KetchDataCenter.UAT);
 
   // Global options
   const [organization, setOrganization] = useState<string | undefined>(
-    'ketch_samples',
+    'ethansch061226',
   );
   const [property, setProperty] = useState<string | undefined>(
-    'react_native_sample_app',
+    'website_smart_tag',
   );
-  const [language, setLanguage] = useState<string | undefined>(undefined);
+  const [language, setLanguage] = useState<string | undefined>('en');
   const [jurisdiction, setJurisdiction] = useState<string | undefined>(
     undefined,
   );
   const [region, setRegion] = useState<string | undefined>(undefined);
-  const [environment, setEnvironment] = useState<string | undefined>(undefined);
+  const [environment, setEnvironment] = useState<string | undefined>('production');
   const [identityName, setIdentityName] = useState('');
   const [identityValue, setIdentityValue] = useState('');
   const [identities, setIdentities] = useState({}); // TODO:JB - Default identities
@@ -74,6 +289,108 @@ function Main(): React.JSX.Element {
   const [initialTab, setInitialTab] = useState<PreferenceTab>(
     PreferenceTab.OverviewTab,
   );
+  const [attStatus, setAttStatus] = useState('N/A');
+
+  const ATT_LAST_STATUS_KEY = 'ketch_att_last';
+
+  const refreshAttState = async (logEvent = false) => {
+    if (Platform.OS !== 'ios') {
+      return;
+    }
+    const status = (await trackingAuthorizationStatusString()) ?? 'unknown';
+    const prev =
+      (await DefaultPreference.get(ATT_LAST_STATUS_KEY)) ?? 'notDetermined';
+    setAttStatus(status);
+    updateDashboard({attStatus: status, ketchAtt: status, ketchAttPrev: prev});
+    if (logEvent) {
+      const message = formatAttState(status, prev);
+      appendLog(`ATT: ${message}`);
+      console.log('[KetchSample] ATT:', message);
+    }
+  };
+
+  useEffect(() => {
+    refreshAttState().catch(() => {});
+  }, [updateDashboard]);
+
+  const handleRequestAtt = async () => {
+    const status = await requestTrackingAuthorization();
+    const value = status ?? 'unknown';
+    setAttStatus(value);
+    const prev =
+      (await DefaultPreference.get(ATT_LAST_STATUS_KEY)) ?? 'notDetermined';
+    updateDashboard({attStatus: value, ketchAtt: value, ketchAttPrev: prev});
+    const message = formatAttState(value, prev);
+    appendLog(`ATT requested: ${message}`);
+    console.log('[KetchSample] ATT requested:', message);
+    ketch.load();
+  };
+
+  const handleReloadWebView = async () => {
+    await refreshAttState(true);
+    ketch.load();
+    appendLog('WebView reload requested');
+  };
+
+  const runHeadlessLocation = async () => {
+    updateDashboard({headlessLocationResult: 'Loading...'});
+    try {
+      const response = await ketch.fetchLocation?.();
+      const code = response?.location?.countryCode ?? '?';
+      updateDashboard({headlessLocationResult: `OK: ${code}`});
+      appendLog(`headless location: ${code}`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      updateDashboard({headlessLocationResult: `Error: ${message}`});
+    }
+  };
+
+  const runHeadlessBootstrap = async () => {
+    updateDashboard({headlessBootstrapResult: 'Loading...'});
+    try {
+      const boot = await ketch.fetchBootstrapConfiguration?.();
+      const count = Array.isArray(boot?.purposes) ? boot.purposes.length : 0;
+      updateDashboard({headlessBootstrapResult: `OK: ${count} purpose(s)`});
+      appendLog('headless bootstrap OK');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      updateDashboard({headlessBootstrapResult: `Error: ${message}`});
+    }
+  };
+
+  const runHeadlessConsent = async () => {
+    updateDashboard({headlessConsentResult: 'Loading...'});
+    try {
+      const identities = {
+        email: `headless-${Date.now()}@integration.ketch.test`,
+      };
+      await ketch.fetchLocation?.();
+      await ketch.fetchBootstrapConfiguration?.();
+      const env = environment?.trim() || 'production';
+      const full = await ketch.fetchFullConfiguration?.({
+        organizationCode: organization ?? 'ethansch061226',
+        propertyCode: property ?? 'website_smart_tag',
+        environmentCode: env,
+      });
+      const config = consentConfigFromConfiguration({
+        configuration: full ?? {},
+        identities,
+        organizationCode: organization ?? 'ethansch061226',
+        propertyCode: property ?? 'website_smart_tag',
+        environmentCode: env,
+      });
+      const consent = await ketch.fetchConsent?.(config);
+      const count =
+        consent?.purposes && Object.keys(consent.purposes).length > 0
+          ? Object.keys(consent.purposes).length
+          : Object.keys(consent?.protocols ?? {}).length;
+      updateDashboard({headlessConsentResult: `OK: ${count} item(s)`});
+      appendLog('headless consent OK');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      updateDashboard({headlessConsentResult: `Error: ${message}`});
+    }
+  };
 
   // Reset identities
   const handleResetIdentityPress = () => {
@@ -132,6 +449,65 @@ function Main(): React.JSX.Element {
         <View
           style={styles.sectionsContainer}
           onTouchStart={() => Keyboard.dismiss()}>
+          <Section title="SDK Health Dashboard">
+            <View style={styles.sectionVerticalContainer}>
+              <Text style={styles.dashboardSubtitle}>Connection</Text>
+              <DashboardRow label="Init" value={dashboard.initState} />
+              <DashboardRow label="Status" value={dashboard.statusText} />
+              <DashboardRow
+                label="Org / Property / Env"
+                value={`${organization ?? ''} / ${property ?? ''} / ${environment ?? 'production'}`}
+              />
+              <DashboardRow
+                label="Data center"
+                value={dataCenterLabels[selectedRegion]}
+              />
+              <Text style={styles.dashboardSubtitle}>WebView / Experience</Text>
+              <DashboardRow label="Load" value={dashboard.loadState} />
+              <DashboardRow label="Visibility" value={dashboard.experienceVisibility} />
+              <DashboardRow label="Dismiss" value={dashboard.dismissReason} />
+              <DashboardRow label="WebView" value={dashboard.webViewVisible} />
+              {Platform.OS === 'ios' && (
+                <>
+                  <DashboardRow label="ketch_att" value={dashboard.ketchAtt} />
+                  <DashboardRow
+                    label="ketch_att_prev"
+                    value={dashboard.ketchAttPrev}
+                  />
+                </>
+              )}
+              {Platform.OS === 'ios' && (
+                <>
+                  <Text style={styles.dashboardSubtitle}>ATT (iOS)</Text>
+                  <DashboardRow label="Native ATT" value={dashboard.attStatus} />
+                </>
+              )}
+              <Text style={styles.dashboardSubtitle}>Privacy / Consent State</Text>
+              <DashboardRow label="Environment" value={dashboard.environment} />
+              <DashboardRow label="Jurisdiction" value={dashboard.jurisdiction} />
+              <DashboardRow label="Region" value={dashboard.region} />
+              <DashboardRow label="Consent" value={truncate(dashboard.consent)} />
+              <DashboardRow label="US Privacy" value={truncate(dashboard.usPrivacy)} />
+              <DashboardRow label="TCF" value={truncate(dashboard.tcf)} />
+              <DashboardRow label="GPP" value={truncate(dashboard.gpp)} />
+              <Text style={styles.dashboardSubtitle}>Headless (live CDN)</Text>
+              <DashboardRow label="Location" value={dashboard.headlessLocationResult} />
+              <DashboardRow label="Bootstrap" value={dashboard.headlessBootstrapResult} />
+              <DashboardRow label="Consent" value={dashboard.headlessConsentResult} />
+              <View style={styles.sectionHorizontalContainer}>
+                <Button title="Fetch Location" onPress={runHeadlessLocation} />
+                <Button title="Fetch Bootstrap" onPress={runHeadlessBootstrap} />
+                <Button title="Cold Start" onPress={runHeadlessConsent} />
+              </View>
+              <Text style={styles.dashboardSubtitle}>Event Log</Text>
+              <Text style={styles.eventLog}>
+                {dashboard.eventLog.length === 0
+                  ? 'Waiting for events...'
+                  : dashboard.eventLog.join('\n')}
+              </Text>
+            </View>
+          </Section>
+
           {/* Global options */}
           <Section
             title="Global Options"
@@ -281,6 +657,18 @@ function Main(): React.JSX.Element {
             </View>
           </Section>
 
+          {Platform.OS === 'ios' && (
+            <Section title="App Tracking Transparency">
+              <View style={styles.sectionVerticalContainer}>
+                <Text style={styles.attStatus}>ATT: {attStatus}</Text>
+                <View style={styles.sectionHorizontalContainer}>
+                  <Button title="Request ATT" onPress={handleRequestAtt} />
+                  <Button title="Reload WebView" onPress={handleReloadWebView} />
+                </View>
+              </View>
+            </Section>
+          )}
+
           {/* SDK Actions */}
           <Section title="Actions" subtitle="Trigger some SDK functionality">
             <>
@@ -292,13 +680,27 @@ function Main(): React.JSX.Element {
                 <View style={styles.sectionHorizontalContainer}>
                   <Button
                     title="Log Consent"
-                    onPress={() => console.log(ketch.getConsent())}
+                    onPress={() => {
+                      const consent = ketch.getConsent();
+                      const summary = consent
+                        ? formatConsent(consent)
+                        : 'no consent cached';
+                      appendLog(`getConsent: ${summary}`);
+                      console.log('[KetchSample] getConsent:', summary);
+                    }}
                   />
                   <Button
                     title="Log Protocols"
                     onPress={consoleLogPrivacyDataFromStorage}
                   />
-                  <Button title="Load" onPress={ketch.load} />
+                  <Button
+                    title="Load"
+                    onPress={() => {
+                      updateDashboard({loadState: 'loading'});
+                      setStatus('Load called');
+                      ketch.load();
+                    }}
+                  />
                   <Button
                     title="Apply CSS"
                     onPress={() =>
@@ -328,6 +730,8 @@ const styles = StyleSheet.create({
 
   sectionTitle: {fontSize: 20, marginBottom: 8, color: 'black'},
 
+  attStatus: {color: 'black', marginBottom: 8},
+
   sectionVerticalContainer: {
     flexDirection: 'column',
     gap: 8,
@@ -351,6 +755,43 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: 8,
     paddingTop: 20,
+  },
+
+  dashboardSubtitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: 'black',
+    marginTop: 8,
+  },
+
+  dashboardRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 4,
+  },
+
+  dashboardLabel: {
+    width: 120,
+    fontSize: 12,
+    color: 'black',
+  },
+
+  dashboardValue: {
+    flex: 1,
+    fontSize: 12,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    color: 'black',
+  },
+
+  eventLog: {
+    fontSize: 11,
+    fontFamily: Platform.OS === 'ios' ? 'Menlo' : 'monospace',
+    color: 'black',
+    minHeight: 80,
+    padding: 8,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
   },
 });
 

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1893,7 +1893,7 @@ __metadata:
 
 "@ketch-com/ketch-react-native@file:../package::locator=example%40workspace%3A.":
   version: 0.6.9
-  resolution: "@ketch-com/ketch-react-native@file:../package#../package::hash=fb22c8&locator=example%40workspace%3A."
+  resolution: "@ketch-com/ketch-react-native@file:../package#../package::hash=a57895&locator=example%40workspace%3A."
   peerDependencies:
     expo-shared-preferences: ">=0.4.0"
     react: ">=18.2.0"
@@ -1903,7 +1903,7 @@ __metadata:
   peerDependenciesMeta:
     expo-shared-preferences:
       optional: true
-  checksum: 10c0/1d9e39ad7f32f23d440336fac6072e08e5a63a3b47123e9559fab69ce283d9bb554f424c767ef2407ead438db653e32ce23bd70ad507ee065f16ca91e582fcdb
+  checksum: 10c0/3a6c25f99960ef7892921c0a5caf95a52d1281c3d6e1269bb89c05a70ee202180fbb11c7ed5da61a8b42dc190f4756632674d49da375b8482ea20a9f12f7bb3f
   languageName: node
   linkType: hard
 

--- a/package/__tests__/headlessApiClient.test.ts
+++ b/package/__tests__/headlessApiClient.test.ts
@@ -1,0 +1,346 @@
+import {
+  consentConfigToJson,
+  consentUpdateToJson,
+  HeadlessException,
+  MigrationOption,
+  withoutProtocols,
+} from '../src/headless/headlessTypes';
+import {
+  HeadlessApiClient,
+  type FetchFn,
+} from '../src/headless/headlessApiClient';
+import { KetchDataCenter, MobileSdkUrlByDataCenterMap } from '../src/enums';
+
+const consentConfig = {
+  organizationCode: 'org',
+  propertyCode: 'prop',
+  environmentCode: 'production',
+  jurisdictionCode: 'default',
+  identities: { id: '1' },
+  purposes: {},
+};
+
+const consentUpdate = {
+  organizationCode: 'org',
+  propertyCode: 'prop',
+  environmentCode: 'production',
+  identities: { id: '1' },
+  jurisdictionCode: 'default',
+  migrationOption: MigrationOption.MIGRATE_DEFAULT,
+  purposes: {
+    analytics: { allowed: 'true', legalBasisCode: 'consent_optin' },
+  },
+};
+
+function mockFetch(
+  impl: () => Promise<{
+    ok: boolean;
+    status: number;
+    text: () => Promise<string>;
+  }>
+): FetchFn {
+  return jest.fn().mockImplementation(impl) as unknown as FetchFn;
+}
+
+function mockFetchResponse(options: {
+  ok: boolean;
+  status?: number;
+  body?: string;
+}): FetchFn {
+  return mockFetch(async () => ({
+    ok: options.ok,
+    status: options.status ?? (options.ok ? 200 : 500),
+    text: async () => options.body ?? '',
+  }));
+}
+
+function mockFetchNetworkError(error: Error): FetchFn {
+  return mockFetch(async () => {
+    throw error;
+  });
+}
+
+describe('HeadlessApiClient URL building', () => {
+  it('buildUrl ip', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(client.buildUrl('/ip')).toBe(
+      'https://global.ketchcdn.com/web/v3/ip'
+    );
+  });
+
+  it('buildUrl bootstrap', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(client.buildUrl('/config/acme/prop/boot.json')).toBe(
+      'https://global.ketchcdn.com/web/v3/config/acme/prop/boot.json'
+    );
+  });
+
+  it('buildUrl fullConfigurationWithHash', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(
+      client.buildUrl('/config/acme/prop/prod/us-ca/en-US/config.json', {
+        hash: '8913461971881236311',
+      })
+    ).toBe(
+      'https://global.ketchcdn.com/web/v3/config/acme/prop/prod/us-ca/en-US/config.json?hash=8913461971881236311'
+    );
+  });
+
+  it('buildUrl eu data center', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.EU });
+    expect(client.buildUrl('/ip')).toBe('https://eu.ketchcdn.com/web/v3/ip');
+  });
+
+  it('ketchDataCenter base URLs', () => {
+    expect(MobileSdkUrlByDataCenterMap[KetchDataCenter.US]).toBe(
+      'https://global.ketchcdn.com/web/v3'
+    );
+    expect(MobileSdkUrlByDataCenterMap[KetchDataCenter.EU]).toBe(
+      'https://eu.ketchcdn.com/web/v3'
+    );
+    expect(MobileSdkUrlByDataCenterMap[KetchDataCenter.UAT]).toBe(
+      'https://dev.ketchcdn.com/web/v3'
+    );
+  });
+});
+
+describe('Headless consent payloads', () => {
+  it('setConsent payload omits protocols', () => {
+    const update = {
+      organizationCode: 'org',
+      propertyCode: 'prop',
+      environmentCode: 'production',
+      identities: { id: '1' },
+      jurisdictionCode: 'default',
+      migrationOption: MigrationOption.MIGRATE_DEFAULT,
+      purposes: {
+        analytics: { allowed: 'true', legalBasisCode: 'consent_optin' },
+      },
+      protocols: { gpp: 'DBABLA~' },
+    };
+    const json = consentUpdateToJson(withoutProtocols(update));
+    expect(json).not.toHaveProperty('protocols');
+    expect(json.organizationCode).toBe('org');
+  });
+
+  it('buildUrl invokeRight', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(client.buildUrl('/rights/switchbitcorp/invoke')).toBe(
+      'https://global.ketchcdn.com/web/v3/rights/switchbitcorp/invoke'
+    );
+  });
+
+  it('preferenceQRUrl matches contract fixture', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(
+      client.preferenceQRUrl({
+        organizationCode: 'switchbitcorp',
+        propertyCode: 'switchbit',
+        environmentCode: 'production',
+        imageSize: 1024,
+        path: '/policy.html',
+        backgroundColor: 'white',
+        foregroundColor: 'black',
+        parameters: { foo: 'bar' },
+      })
+    ).toBe(
+      'https://global.ketchcdn.com/web/v3/qr/switchbitcorp/switchbit/preferences.png?env=production&size=1024&path=%2Fpolicy.html&bgcolor=white&fgcolor=black&foo=bar'
+    );
+  });
+
+  it('buildUrl subscriptions configuration', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(
+      client.buildUrl('/config/switchbitcorp/foo/en-US/bar/subscriptions.json')
+    ).toBe(
+      'https://global.ketchcdn.com/web/v3/config/switchbitcorp/foo/en-US/bar/subscriptions.json'
+    );
+  });
+
+  it('buildUrl profile and subscriptions', () => {
+    const client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+    expect(client.buildUrl('/profile/acme/get')).toBe(
+      'https://global.ketchcdn.com/web/v3/profile/acme/get'
+    );
+    expect(client.buildUrl('/subscriptions/acme/get')).toBe(
+      'https://global.ketchcdn.com/web/v3/subscriptions/acme/get'
+    );
+    expect(client.buildUrl('/subscriptions/acme/update')).toBe(
+      'https://global.ketchcdn.com/web/v3/subscriptions/acme/update'
+    );
+  });
+
+  it('consentConfig payload omits cachedAt', () => {
+    const json = consentConfigToJson({
+      organizationCode: 'org',
+      propertyCode: 'prop',
+      environmentCode: 'production',
+      jurisdictionCode: 'default',
+      identities: {},
+      purposes: {},
+    });
+    expect(json).not.toHaveProperty('cachedAt');
+  });
+});
+
+describe('HeadlessApiClient consent', () => {
+  it('fetchConsent propagates HTTP failure', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({ ok: false, status: 500 }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).rejects.toThrow(
+      HeadlessException
+    );
+    await expect(client.fetchConsent(consentConfig)).rejects.toThrow(
+      'HTTP 500'
+    );
+  });
+
+  it('setConsentOnServer propagates network failure', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchNetworkError(new TypeError('Network request failed')),
+    });
+
+    await expect(client.setConsentOnServer(consentUpdate)).rejects.toThrow(
+      TypeError
+    );
+  });
+
+  it('fetchConsent returns empty consent on 200 null body', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({ ok: true, body: 'null' }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).resolves.toEqual({
+      purposes: {},
+    });
+  });
+
+  it('fetchConsent returns empty consent on 200 blank body', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({ ok: true, body: '' }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).resolves.toEqual({
+      purposes: {},
+    });
+  });
+
+  it('setConsentOnServer accepts protocols-only response', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({ protocols: { gpp: 'DBABLA~' } }),
+      }),
+    });
+
+    await expect(client.setConsentOnServer(consentUpdate)).resolves.toEqual({
+      purposes: undefined,
+      vendors: undefined,
+      protocols: { gpp: 'DBABLA~' },
+    });
+  });
+});
+
+describe('fetchProtocols', () => {
+  it('preserves purposes when protocols are missing', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({
+          purposes: { analytics: true, marketing: false },
+        }),
+      }),
+    });
+
+    await expect(client.fetchProtocols(consentConfig)).resolves.toEqual({
+      purposes: { analytics: true, marketing: false },
+      vendors: undefined,
+    });
+  });
+});
+
+describe('hasUsableConsentFields (via fetchConsent)', () => {
+  it('returns empty consent when purposes and protocols are empty objects', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({ purposes: {}, protocols: {} }),
+      }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).resolves.toEqual({
+      purposes: {},
+    });
+  });
+
+  it('accepts purposes-only response', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({ purposes: { analytics: true } }),
+      }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).resolves.toEqual({
+      purposes: { analytics: true },
+      vendors: undefined,
+      protocols: undefined,
+    });
+  });
+
+  it('accepts protocols-only response', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({ protocols: { gpp: 'DBABLA~' } }),
+      }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).resolves.toEqual({
+      purposes: undefined,
+      vendors: undefined,
+      protocols: { gpp: 'DBABLA~' },
+    });
+  });
+
+  it('returns empty consent when neither purposes nor protocols are present', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({ vendors: ['1'] }),
+      }),
+    });
+
+    await expect(client.fetchConsent(consentConfig)).resolves.toEqual({
+      purposes: {},
+    });
+  });
+
+  it('setConsentOnServer falls back when response has empty purposes and protocols', async () => {
+    const client = new HeadlessApiClient({
+      dataCenter: KetchDataCenter.US,
+      fetchFn: mockFetchResponse({
+        ok: true,
+        body: JSON.stringify({ purposes: {}, protocols: {} }),
+      }),
+    });
+
+    await expect(client.setConsentOnServer(consentUpdate)).resolves.toEqual({
+      purposes: { analytics: true },
+      vendors: undefined,
+      protocols: {},
+    });
+  });
+});

--- a/package/__tests__/headlessCdnIntegration.test.ts
+++ b/package/__tests__/headlessCdnIntegration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Live CDN headless tests — require network.
+ *
+ * Run: `KETCH_INTEGRATION_TESTS=1 npm run test:integration`
+ */
+import { HeadlessApiClient } from '../src/headless/headlessApiClient';
+import {
+  MigrationOption,
+  withoutProtocols,
+  type ConsentUpdate,
+} from '../src/headless/headlessTypes';
+import { KetchDataCenter } from '../src/enums';
+import { HeadlessIntegrationSupport } from './headlessIntegrationSupport';
+
+const runIntegration = process.env.KETCH_INTEGRATION_TESTS === '1';
+
+(runIntegration ? describe : describe.skip)('Headless CDN integration', () => {
+  jest.setTimeout(60_000);
+
+  let client: HeadlessApiClient;
+
+  beforeEach(() => {
+    client = new HeadlessApiClient({ dataCenter: KetchDataCenter.US });
+  });
+
+  it('fetchLocation returns GeoIP from CDN', async () => {
+    const location = await client.fetchLocation();
+    expect(location.location?.countryCode).toBeTruthy();
+  });
+
+  it('fetchBootstrapConfiguration returns sandbox config', async () => {
+    const boot = await client.fetchBootstrapConfiguration(
+      HeadlessIntegrationSupport.orgCode,
+      HeadlessIntegrationSupport.propertyCode
+    );
+    expect(Object.keys(boot).length).toBeGreaterThan(0);
+    const environments = boot.environments;
+    expect(Array.isArray(environments) && environments.length > 0).toBe(true);
+  });
+
+  it('headless cold start consent round-trip', async () => {
+    const identities = HeadlessIntegrationSupport.uniqueEmailIdentity();
+
+    await client.fetchLocation();
+
+    await client.fetchBootstrapConfiguration(
+      HeadlessIntegrationSupport.orgCode,
+      HeadlessIntegrationSupport.propertyCode
+    );
+
+    const fullConfig = await client.fetchFullConfiguration({
+      organizationCode: HeadlessIntegrationSupport.orgCode,
+      propertyCode: HeadlessIntegrationSupport.propertyCode,
+    });
+
+    const consentConfig =
+      HeadlessIntegrationSupport.consentConfigFromConfiguration({
+        configuration: fullConfig,
+        identities,
+      });
+
+    const consent = await client.fetchConsent(consentConfig);
+    const hasProtocols =
+      consent.protocols != null && Object.keys(consent.protocols).length > 0;
+    const hasPurposes =
+      consent.purposes != null && Object.keys(consent.purposes).length > 0;
+    expect(hasProtocols || hasPurposes).toBe(true);
+
+    const purposeCode = Object.keys(consentConfig.purposes)[0];
+    const legalBasis = consentConfig.purposes[purposeCode || ''];
+
+    const update: ConsentUpdate = {
+      organizationCode: HeadlessIntegrationSupport.orgCode,
+      propertyCode: HeadlessIntegrationSupport.propertyCode,
+      environmentCode: HeadlessIntegrationSupport.environmentCode,
+      identities,
+      jurisdictionCode: consentConfig.jurisdictionCode,
+      migrationOption: MigrationOption.MIGRATE_DEFAULT,
+      purposes: {
+        [purposeCode || '']: {
+          allowed: 'true',
+          legalBasisCode: legalBasis?.legalBasisCode || '',
+        },
+      },
+    };
+
+    const updated = await client.setConsentOnServer(withoutProtocols(update));
+    expect(updated.purposes?.[purposeCode || '']).toBeDefined();
+  });
+});

--- a/package/__tests__/headlessIntegrationSupport.ts
+++ b/package/__tests__/headlessIntegrationSupport.ts
@@ -1,0 +1,67 @@
+import type { ConsentConfig } from '../src/headless/headlessTypes';
+
+/** Shared sandbox config for live CDN integration tests. */
+export const HeadlessIntegrationSupport = {
+  orgCode: 'ketch_samples',
+  propertyCode: 'react_native_sample_app',
+  environmentCode: 'production',
+
+  uniqueEmailIdentity(): Record<string, string> {
+    return {
+      email: `headless-${Date.now()}@integration.ketch.test`,
+    };
+  },
+
+  consentConfigFromConfiguration(options: {
+    configuration: Record<string, unknown>;
+    identities: Record<string, string>;
+    organizationCode?: string;
+    propertyCode?: string;
+    environmentCode?: string;
+  }): ConsentConfig {
+    const {
+      configuration,
+      identities,
+      organizationCode = HeadlessIntegrationSupport.orgCode,
+      propertyCode = HeadlessIntegrationSupport.propertyCode,
+      environmentCode = HeadlessIntegrationSupport.environmentCode,
+    } = options;
+
+    const jurisdictionMap = configuration.jurisdiction;
+    let jurisdiction = 'us';
+    if (jurisdictionMap && typeof jurisdictionMap === 'object') {
+      const map = jurisdictionMap as Record<string, unknown>;
+      jurisdiction = String(
+        map.code ?? map.defaultJurisdictionCode ?? jurisdiction
+      );
+    }
+
+    const purposesList = configuration.purposes;
+    const purposes: ConsentConfig['purposes'] = {};
+    if (Array.isArray(purposesList)) {
+      for (const entry of purposesList) {
+        if (entry && typeof entry === 'object') {
+          const purpose = entry as Record<string, unknown>;
+          const code = purpose.code?.toString();
+          const legalBasis = purpose.legalBasisCode?.toString();
+          if (code && legalBasis) {
+            purposes[code] = { legalBasisCode: legalBasis };
+          }
+        }
+      }
+    }
+
+    if (Object.keys(purposes).length === 0) {
+      throw new Error('Configuration returned no purposes');
+    }
+
+    return {
+      organizationCode,
+      propertyCode,
+      environmentCode,
+      jurisdictionCode: jurisdiction,
+      identities,
+      purposes,
+    };
+  },
+};

--- a/package/__tests__/helpers.test.ts
+++ b/package/__tests__/helpers.test.ts
@@ -1,0 +1,58 @@
+import {
+  createUrlParamsObject,
+  getWebViewConfigKey,
+} from '../src/util/helpers';
+import { KetchDataCenter, LogLevel } from '../src/enums';
+
+describe('createUrlParamsObject', () => {
+  it('includes ketch_att when ketchAtt is set', () => {
+    const params = createUrlParamsObject({
+      organizationCode: 'acme',
+      propertyCode: 'prop',
+      dataCenter: KetchDataCenter.US,
+      ketchAtt: 'denied',
+    });
+
+    expect(params.ketch_att).toBe('denied');
+    expect(params.organizationCode).toBe('acme');
+  });
+
+  it('maps data center and log level', () => {
+    const params = createUrlParamsObject({
+      organizationCode: 'acme',
+      propertyCode: 'prop',
+      dataCenter: KetchDataCenter.US,
+      logLevel: LogLevel.ERROR,
+    });
+
+    expect(params.ketch_mobilesdk_url).toContain('web/v3');
+    expect(params.ketch_log).toBe(LogLevel.ERROR);
+  });
+
+  it('maps UAT data center to dev CDN', () => {
+    const params = createUrlParamsObject({
+      organizationCode: 'acme',
+      propertyCode: 'prop',
+      dataCenter: KetchDataCenter.UAT,
+    });
+
+    expect(params.ketch_mobilesdk_url).toBe('https://dev.ketchcdn.com/web/v3');
+  });
+
+  it('changes web view config key when data center changes', () => {
+    const base = {
+      organizationCode: 'acme',
+      propertyCode: 'prop',
+    };
+    const usKey = getWebViewConfigKey({
+      ...base,
+      dataCenter: KetchDataCenter.US,
+    });
+    const uatKey = getWebViewConfigKey({
+      ...base,
+      dataCenter: KetchDataCenter.UAT,
+    });
+
+    expect(usKey).not.toBe(uatKey);
+  });
+});

--- a/package/src/assets/index.ts
+++ b/package/src/assets/index.ts
@@ -118,27 +118,77 @@ export const getIndexHtml = (parameters: KetchMobile) => {
         }
       }
 
+      function installWebResourceUrlOverrides(overrides) {
+        if (!overrides || !Object.keys(overrides).length) return;
+        function resolveUrl(url) {
+          if (!url) return url;
+          if (overrides[url]) return overrides[url];
+          var base = url.split('?')[0].split('#')[0];
+          if (base !== url && overrides[base]) return overrides[base];
+          for (var key in overrides) {
+            if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+            if (key === url || key === base) continue;
+            if (key.charAt(0) === '/' && base.indexOf(key) !== -1) return overrides[key];
+            if (key.indexOf('://') !== -1) continue;
+            if (base.endsWith(key) || base.indexOf('/' + key) !== -1) return overrides[key];
+          }
+          return url;
+        }
+        var srcDesc = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+        if (srcDesc && srcDesc.set) {
+          var nativeSrcSet = srcDesc.set;
+          var nativeSrcGet = srcDesc.get;
+          Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+            set: function (value) { nativeSrcSet.call(this, resolveUrl(value)); },
+            get: nativeSrcGet,
+            configurable: true,
+          });
+        }
+        var origSetAttribute = Element.prototype.setAttribute;
+        Element.prototype.setAttribute = function (name, value) {
+          if (name === 'src' && this.tagName === 'SCRIPT') {
+            return origSetAttribute.call(this, name, resolveUrl(value));
+          }
+          return origSetAttribute.call(this, name, value);
+        };
+        if (window.fetch) {
+          var origFetch = window.fetch.bind(window);
+          window.fetch = function (input, init) {
+            if (typeof input === 'string') {
+              var mapped = resolveUrl(input);
+              if (mapped !== input) input = mapped;
+            } else if (input && input.url) {
+              var mappedUrl = resolveUrl(input.url);
+              if (mappedUrl !== input.url) input = new Request(mappedUrl, input);
+            }
+            return origFetch(input, init);
+          };
+        }
+      }
+
       function initKetchTag(parameters) {
         console.log('Ketch Tag is initialization started...');
-        // Use parameters to set SDK query params here
-        const urlParams = new URLSearchParams(parameters);
+        if (parameters.webResourceUrlOverrides) {
+          installWebResourceUrlOverrides(parameters.webResourceUrlOverrides);
+        }
+
+        // Mirror init params into the URL bar for Ketch Tag; read boot config from
+        // the init object itself (no query-string round-trip).
+        const urlParams = new URLSearchParams();
+        for (const key in parameters) {
+          if (!Object.prototype.hasOwnProperty.call(parameters, key)) continue;
+          const value = parameters[key];
+          if (value !== undefined && value !== null && typeof value !== 'object') {
+            urlParams.set(key, String(value));
+          }
+        }
         window.history.replaceState({}, '', '?' + urlParams.toString());
 
-        console.log('Ketch Parameters BEFORE:', parameters);
-        // Get query parameters
-        let params = new URL(document.location).searchParams;
-
-        console.log('Ketch Parameters AFTER:', params);
-        // Get url override from query parameters
-        let url =
-          params.get('ketch_mobilesdk_url') ||
+        const url =
+          parameters.ketch_mobilesdk_url ||
           'https://global.ketchcdn.com/web/v3';
-
-        // Get property name from query parameters
-        let propertyName = params.get('propertyCode');
-
-        // Get organization code from query parameters
-        let orgCode = params.get('organizationCode');
+        const orgCode = parameters.organizationCode;
+        const propertyName = parameters.propertyCode;
         console.log('Ketch org data:', orgCode, propertyName, url);
 
         if (orgCode && propertyName) {
@@ -162,6 +212,79 @@ export const getIndexHtml = (parameters: KetchMobile) => {
   </body>
 </html>
 `;
+};
+
+/** JS hook body that redirects script/fetch URLs (used in HTML head and beforeContentLoaded). */
+const buildWebResourceUrlOverridesHook = (overridesJson: string) => `(function () {
+  var overrides = ${overridesJson};
+  if (!overrides || !Object.keys(overrides).length) return;
+  function resolveUrl(url) {
+    if (!url) return url;
+    if (overrides[url]) return overrides[url];
+    var base = url.split('?')[0].split('#')[0];
+    if (base !== url && overrides[base]) return overrides[base];
+    for (var key in overrides) {
+      if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+      if (key === url || key === base) continue;
+      if (key.charAt(0) === '/' && base.indexOf(key) !== -1) return overrides[key];
+      if (key.indexOf('://') !== -1) continue;
+      if (base.endsWith(key) || base.indexOf('/' + key) !== -1) return overrides[key];
+    }
+    return url;
+  }
+  var srcDesc = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+  if (srcDesc && srcDesc.set) {
+    var nativeSrcSet = srcDesc.set;
+    var nativeSrcGet = srcDesc.get;
+    Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+      set: function (value) { nativeSrcSet.call(this, resolveUrl(value)); },
+      get: nativeSrcGet,
+      configurable: true,
+    });
+  }
+  var origSetAttribute = Element.prototype.setAttribute;
+  Element.prototype.setAttribute = function (name, value) {
+    if (name === 'src' && this.tagName === 'SCRIPT') {
+      return origSetAttribute.call(this, name, resolveUrl(value));
+    }
+    return origSetAttribute.call(this, name, value);
+  };
+  if (window.fetch) {
+    var origFetch = window.fetch.bind(window);
+    window.fetch = function (input, init) {
+      if (typeof input === 'string') {
+        var mapped = resolveUrl(input);
+        if (mapped !== input) input = mapped;
+      } else if (input && input.url) {
+        var mappedUrl = resolveUrl(input.url);
+        if (mappedUrl !== input.url) input = new Request(mappedUrl, input);
+      }
+      return origFetch(input, init);
+    };
+  }
+})();`;
+
+export const getWebResourceUrlOverridesInjectionScript = (
+  overrides?: Record<string, string>
+): string | undefined => {
+  if (!overrides || !Object.keys(overrides).length) {
+    return undefined;
+  }
+  return `${buildWebResourceUrlOverridesHook(JSON.stringify(overrides))} true;`;
+};
+
+/**
+ * Injects URL override hooks in <head> before any body scripts (iOS WebConfig parity).
+ */
+export const injectWebResourceUrlOverridesIntoHtml = (
+  html: string,
+  overrides?: Record<string, string>
+) => {
+  if (!overrides || !Object.keys(overrides).length) {
+    return html;
+  }
+  const script = `<script>${buildWebResourceUrlOverridesHook(JSON.stringify(overrides))}</script>`;
+  return html.replace('<head>', `<head>\n${script}`);
 };
 
 /**

--- a/package/src/headless/headlessApiClient.ts
+++ b/package/src/headless/headlessApiClient.ts
@@ -1,0 +1,390 @@
+import { KetchDataCenter, MobileSdkUrlByDataCenterMap } from '../enums';
+import type { Consent } from '../types';
+import {
+  consentConfigToJson,
+  consentUpdateToJson,
+  HeadlessException,
+  withoutProtocols,
+  type ConsentConfig,
+  type ConsentUpdate,
+  type FullConfigurationRequest,
+  type GetProfileRequest,
+  type GetProfileResponse,
+  type InvokeRightRequest,
+  type LocationResponse,
+  type PreferenceQRRequest,
+  type PutProfileRequest,
+  type SubscriptionConfigurationRequest,
+  type SubscriptionsRequest,
+  type SubscriptionsResponse,
+  type WebReportRequest,
+} from './headlessTypes';
+
+export type FetchFn = typeof fetch;
+
+/** Native HTTP client mirroring ketch-tag KetchWebAPI (web/v3). */
+export class HeadlessApiClient {
+  private readonly baseUrl: string;
+  private readonly fetchFn: FetchFn;
+
+  constructor(
+    options: {
+      dataCenter?: KetchDataCenter;
+      baseUrl?: string;
+      fetchFn?: FetchFn;
+    } = {}
+  ) {
+    const dataCenter = options.dataCenter ?? KetchDataCenter.US;
+    this.baseUrl = options.baseUrl ?? MobileSdkUrlByDataCenterMap[dataCenter];
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  /** Builds an absolute CDN URL for unit tests and debugging. */
+  buildUrl(path: string, query?: Record<string, string>): string {
+    const normalized = path.startsWith('/') ? path : `/${path}`;
+    const url = new URL(`${this.baseUrl.replace(/\/+$/, '')}${normalized}`);
+    if (query) {
+      Object.entries(query).forEach(([key, value]) => {
+        url.searchParams.set(key, value);
+      });
+    }
+    return url.toString();
+  }
+
+  /** GeoIP / jurisdiction hint (`GET /ip`). */
+  async fetchLocation(): Promise<LocationResponse> {
+    const response = await this.get(this.buildUrl('/ip'));
+    return JSON.parse(response) as LocationResponse;
+  }
+
+  /** Minimal config (`GET .../boot.json`). */
+  async fetchBootstrapConfiguration(
+    organization: string,
+    property: string
+  ): Promise<Record<string, unknown>> {
+    const response = await this.get(
+      this.buildUrl(`/config/${organization}/${property}/boot.json`)
+    );
+    return JSON.parse(response) as Record<string, unknown>;
+  }
+
+  /** Full config with optional env / jurisdiction / language and hash query param. */
+  async fetchFullConfiguration(
+    request: FullConfigurationRequest
+  ): Promise<Record<string, unknown>> {
+    let path = `/config/${request.organizationCode}/${request.propertyCode}`;
+    if (
+      request.environmentCode &&
+      request.jurisdictionCode &&
+      request.languageCode
+    ) {
+      path += `/${request.environmentCode}/${request.jurisdictionCode}/${request.languageCode}`;
+    }
+    path += '/config.json';
+    const query = request.hash ? { hash: request.hash } : undefined;
+    const response = await this.get(this.buildUrl(path, query));
+    return JSON.parse(response) as Record<string, unknown>;
+  }
+
+  /** Server consent including `protocols` (`POST .../consent/{org}/get`). */
+  async fetchConsent(config: ConsentConfig): Promise<Consent> {
+    const path = `/consent/${config.organizationCode}/get`;
+    const response = await this.post(path, consentConfigToJson(config));
+    if (!response || response === 'null') {
+      return emptyConsent();
+    }
+    const consent = parseConsent(
+      JSON.parse(response) as Record<string, unknown>
+    );
+    return hasUsableConsentFields(consent) ? consent : emptyConsent();
+  }
+
+  /** Protocol strings only (same endpoint as fetchConsent). */
+  async fetchProtocols(config: ConsentConfig): Promise<Consent> {
+    const response = await this.fetchConsent(config);
+    if (!response.protocols || Object.keys(response.protocols).length === 0) {
+      return {
+        purposes: response.purposes,
+        vendors: response.vendors,
+      };
+    }
+    return response;
+  }
+
+  /** Invokes a data subject right (`POST .../rights/{org}/invoke`). */
+  async invokeRight(request: InvokeRightRequest): Promise<void> {
+    const path = `/rights/${request.organizationCode}/invoke`;
+    await this.postVoid(path, request as unknown as Record<string, unknown>);
+  }
+
+  /** Gets profile preferences (`POST .../profile/{org}/get`). */
+  async getProfile(request: GetProfileRequest): Promise<GetProfileResponse> {
+    const path = `/profile/${request.organizationCode}/get`;
+    const response = await this.post(
+      path,
+      request as unknown as Record<string, unknown>
+    );
+    return JSON.parse(response) as GetProfileResponse;
+  }
+
+  /** Updates profile preferences (`POST .../profile/{org}/put`). */
+  async putProfile(request: PutProfileRequest): Promise<void> {
+    const path = `/profile/${request.organizationCode}/put`;
+    await this.postVoid(path, request as unknown as Record<string, unknown>);
+  }
+
+  /** Gets subscription topics/controls (`POST .../subscriptions/{org}/get`). */
+  async getSubscriptions(
+    request: SubscriptionsRequest
+  ): Promise<SubscriptionsResponse> {
+    const path = `/subscriptions/${request.organizationCode}/get`;
+    const response = await this.post(
+      path,
+      request as unknown as Record<string, unknown>
+    );
+    return JSON.parse(response) as SubscriptionsResponse;
+  }
+
+  /** Updates subscription topics/controls (`POST .../subscriptions/{org}/update`). */
+  async setSubscriptions(request: SubscriptionsRequest): Promise<void> {
+    const path = `/subscriptions/${request.organizationCode}/update`;
+    await this.postVoid(path, request as unknown as Record<string, unknown>);
+  }
+
+  /** Subscriptions tab config (`GET .../subscriptions.json`). */
+  async fetchSubscriptionsConfiguration(
+    request: SubscriptionConfigurationRequest
+  ): Promise<Record<string, unknown>> {
+    const path = `/config/${request.organizationCode}/${request.propertyCode}/${request.languageCode}/${request.experienceCode}/subscriptions.json`;
+    const response = await this.get(this.buildUrl(path));
+    return JSON.parse(response) as Record<string, unknown>;
+  }
+
+  /** Builds preferences QR image URL (no HTTP). */
+  preferenceQRUrl(request: PreferenceQRRequest): string {
+    const query: Record<string, string> = {};
+    if (request.environmentCode) {
+      query.env = request.environmentCode;
+    }
+    if (request.imageSize != null) {
+      query.size = String(request.imageSize);
+    }
+    if (request.path) {
+      query.path = request.path;
+    }
+    if (request.backgroundColor) {
+      query.bgcolor = request.backgroundColor;
+    }
+    if (request.foregroundColor) {
+      query.fgcolor = request.foregroundColor;
+    }
+    if (request.parameters) {
+      Object.assign(query, request.parameters);
+    }
+    return this.buildUrl(
+      `/qr/${request.organizationCode}/${request.propertyCode}/preferences.png`,
+      Object.keys(query).length > 0 ? query : undefined
+    );
+  }
+
+  /** Telemetry upload (`POST /report/{channel}`). */
+  async webReport(channel: string, request: WebReportRequest): Promise<void> {
+    await this.postVoid(
+      `/report/${channel}`,
+      request as unknown as Record<string, unknown>
+    );
+  }
+
+  /** Updates consent; returns server response with computed `protocols`. */
+  async setConsentOnServer(update: ConsentUpdate): Promise<Consent> {
+    const path = `/consent/${update.organizationCode}/update`;
+    const response = await this.post(
+      path,
+      consentUpdateToJson(withoutProtocols(update))
+    );
+    if (!response || response === 'null') {
+      return consentFromUpdate(update);
+    }
+    const consent = parseConsent(
+      JSON.parse(response) as Record<string, unknown>
+    );
+    return hasUsableConsentFields(consent)
+      ? consent
+      : consentFromUpdate(update);
+  }
+
+  private async get(url: string): Promise<string> {
+    const response = await this.fetchFn(url, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) {
+      throw new HeadlessException(`HTTP ${response.status} for ${url}`);
+    }
+    return response.text();
+  }
+
+  private async postVoid(
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<void> {
+    const url = this.buildUrl(path);
+    const response = await this.fetchFn(url, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new HeadlessException(`HTTP ${response.status} for ${url}`);
+    }
+  }
+
+  private async post(
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<string> {
+    const url = this.buildUrl(path);
+    const response = await this.fetchFn(url, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new HeadlessException(`HTTP ${response.status} for ${url}`);
+    }
+    return response.text();
+  }
+}
+
+function emptyConsent(): Consent {
+  return { purposes: {} };
+}
+
+function hasUsableConsentFields(consent: Consent): boolean {
+  const hasPurposes =
+    consent.purposes != null && Object.keys(consent.purposes).length > 0;
+  const hasProtocols =
+    consent.protocols != null && Object.keys(consent.protocols).length > 0;
+  return hasPurposes || hasProtocols;
+}
+
+function parseConsent(json: Record<string, unknown>): Consent {
+  const purposes =
+    json.purposes && typeof json.purposes === 'object'
+      ? (json.purposes as Record<string, boolean>)
+      : undefined;
+  const vendors = Array.isArray(json.vendors)
+    ? (json.vendors as string[])
+    : undefined;
+  const protocols =
+    json.protocols && typeof json.protocols === 'object'
+      ? (json.protocols as Record<string, string>)
+      : undefined;
+  return { purposes, vendors, protocols };
+}
+
+function consentFromUpdate(update: ConsentUpdate): Consent {
+  const purposes = Object.fromEntries(
+    Object.entries(update.purposes).map(([key, value]) => [
+      key,
+      value.allowed.toLowerCase() === 'true',
+    ])
+  );
+  return {
+    purposes,
+    vendors: update.vendors,
+    protocols: {},
+  };
+}
+
+export interface KetchHeadlessOptions {
+  dataCenter?: KetchDataCenter;
+  baseUrl?: string;
+}
+
+/**
+ * Headless web/v3 API entry point for React Native (pre-WebView ATT flows).
+ * Uses fetch on both iOS and Android; does not require a WebView.
+ */
+export class KetchHeadless {
+  private readonly client: HeadlessApiClient;
+
+  constructor(options: KetchHeadlessOptions = {}) {
+    this.client = new HeadlessApiClient(options);
+  }
+
+  buildUrl(path: string, query?: Record<string, string>): string {
+    return this.client.buildUrl(path, query);
+  }
+
+  fetchLocation(): Promise<LocationResponse> {
+    return this.client.fetchLocation();
+  }
+
+  fetchBootstrapConfiguration(
+    organization: string,
+    property: string
+  ): Promise<Record<string, unknown>> {
+    return this.client.fetchBootstrapConfiguration(organization, property);
+  }
+
+  fetchFullConfiguration(
+    request: FullConfigurationRequest
+  ): Promise<Record<string, unknown>> {
+    return this.client.fetchFullConfiguration(request);
+  }
+
+  fetchConsent(config: ConsentConfig): Promise<Consent> {
+    return this.client.fetchConsent(config);
+  }
+
+  fetchProtocols(config: ConsentConfig): Promise<Consent> {
+    return this.client.fetchProtocols(config);
+  }
+
+  setConsentOnServer(update: ConsentUpdate): Promise<Consent> {
+    return this.client.setConsentOnServer(update);
+  }
+
+  invokeRight(request: InvokeRightRequest): Promise<void> {
+    return this.client.invokeRight(request);
+  }
+
+  getProfile(request: GetProfileRequest): Promise<GetProfileResponse> {
+    return this.client.getProfile(request);
+  }
+
+  putProfile(request: PutProfileRequest): Promise<void> {
+    return this.client.putProfile(request);
+  }
+
+  getSubscriptions(
+    request: SubscriptionsRequest
+  ): Promise<SubscriptionsResponse> {
+    return this.client.getSubscriptions(request);
+  }
+
+  setSubscriptions(request: SubscriptionsRequest): Promise<void> {
+    return this.client.setSubscriptions(request);
+  }
+
+  fetchSubscriptionsConfiguration(
+    request: SubscriptionConfigurationRequest
+  ): Promise<Record<string, unknown>> {
+    return this.client.fetchSubscriptionsConfiguration(request);
+  }
+
+  preferenceQRUrl(request: PreferenceQRRequest): string {
+    return this.client.preferenceQRUrl(request);
+  }
+
+  webReport(channel: string, request: WebReportRequest): Promise<void> {
+    return this.client.webReport(channel, request);
+  }
+}

--- a/package/src/headless/headlessTypes.ts
+++ b/package/src/headless/headlessTypes.ts
@@ -1,0 +1,241 @@
+/** GeoIP details from `GET /ip` (ketch-types `IPInfo`). */
+export interface IPInfo {
+  ip?: string;
+  hostname?: string;
+  continentCode?: string;
+  continentName?: string;
+  countryCode?: string;
+  countryName?: string;
+  regionCode?: string;
+  regionName?: string;
+  city?: string;
+  postalCode?: string;
+  timezone?: string;
+}
+
+/** Response from headless `fetchLocation()`. */
+export interface LocationResponse {
+  location?: IPInfo;
+}
+
+/** Parameters for v3 `getFullConfiguration`. */
+export interface FullConfigurationRequest {
+  organizationCode: string;
+  propertyCode: string;
+  environmentCode?: string;
+  jurisdictionCode?: string;
+  languageCode?: string;
+  hash?: string;
+}
+
+export interface PurposeLegalBasis {
+  legalBasisCode: string;
+}
+
+/** Request body for `POST /consent/{org}/get`. */
+export interface ConsentConfig {
+  organizationCode: string;
+  propertyCode: string;
+  environmentCode: string;
+  jurisdictionCode: string;
+  identities: Record<string, string>;
+  purposes: Record<string, PurposeLegalBasis>;
+}
+
+export enum MigrationOption {
+  MIGRATE_DEFAULT = 'MIGRATE_DEFAULT',
+  MIGRATE_NEVER = 'MIGRATE_NEVER',
+  MIGRATE_FROM_ALLOW = 'MIGRATE_FROM_ALLOW',
+  MIGRATE_FROM_DENY = 'MIGRATE_FROM_DENY',
+  MIGRATE_ALWAYS = 'MIGRATE_ALWAYS',
+}
+
+export interface PurposeAllowedLegalBasis {
+  allowed: string;
+  legalBasisCode: string;
+}
+
+/** Request body for `POST /consent/{org}/update`. */
+export interface ConsentUpdate {
+  organizationCode: string;
+  propertyCode: string;
+  environmentCode: string;
+  identities: Record<string, string>;
+  jurisdictionCode: string;
+  migrationOption: MigrationOption;
+  purposes: Record<string, PurposeAllowedLegalBasis>;
+  vendors?: string[];
+  protocols?: Record<string, string>;
+}
+
+export class HeadlessException extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'HeadlessException';
+  }
+}
+
+export function consentConfigToJson(
+  config: ConsentConfig
+): Record<string, unknown> {
+  return {
+    organizationCode: config.organizationCode,
+    propertyCode: config.propertyCode,
+    environmentCode: config.environmentCode,
+    jurisdictionCode: config.jurisdictionCode,
+    identities: config.identities,
+    purposes: config.purposes,
+  };
+}
+
+export function consentUpdateToJson(
+  update: ConsentUpdate
+): Record<string, unknown> {
+  return {
+    organizationCode: update.organizationCode,
+    propertyCode: update.propertyCode,
+    environmentCode: update.environmentCode,
+    identities: update.identities,
+    jurisdictionCode: update.jurisdictionCode,
+    migrationOption: update.migrationOption,
+    purposes: update.purposes,
+    ...(update.vendors != null ? { vendors: update.vendors } : {}),
+  };
+}
+
+export function withoutProtocols(update: ConsentUpdate): ConsentUpdate {
+  const rest = { ...update };
+  delete rest.protocols;
+  return rest;
+}
+
+/** ketch-types `DataSubject` */
+export interface DataSubject {
+  email: string;
+  firstName: string;
+  lastName: string;
+  country?: string;
+  stateRegion?: string;
+  city?: string;
+  description?: string;
+  phone?: string;
+  postalCode?: string;
+  addressLine1?: string;
+  addressLine2?: string;
+}
+
+/** ketch-types `InvokeRightRequest` */
+export interface InvokeRightRequest {
+  organizationCode: string;
+  propertyCode: string;
+  environmentCode: string;
+  identities: Record<string, string>;
+  jurisdictionCode: string;
+  rightCode: string;
+  user: DataSubject;
+  controllerCode?: string;
+  invokedAt?: number;
+  recaptchaToken?: string;
+  regionCode?: string;
+  isAuthenticated?: boolean;
+}
+
+export interface ProfilePreferencesIdentity {
+  identitySpace: string;
+  identityValue: string;
+}
+
+export interface ProfilePreferencesAttribute {
+  attributeCode: string;
+  attributeValue?: string;
+  source: string;
+}
+
+export interface ProfilePreferencesContext {
+  source: string;
+  updatedAt?: number;
+  configId?: string;
+}
+
+/** ketch-types `GetProfileRequest` */
+export interface GetProfileRequest {
+  organizationCode: string;
+  propertyCode: string;
+  jurisdictionCode: string;
+  languageCode: string;
+  identities: ProfilePreferencesIdentity[];
+  controllerCode?: string;
+  environmentCode?: string;
+  accountID?: string;
+  regionCode?: string;
+}
+
+/** ketch-types `GetProfileResponse` */
+export interface GetProfileResponse {
+  controllerCode?: string;
+  propertyCode?: string;
+  environmentCode?: string;
+  jurisdictionCode?: string;
+  regionCode?: string;
+  attributes?: ProfilePreferencesAttribute[];
+}
+
+/** ketch-types `PutProfileRequest` */
+export interface PutProfileRequest {
+  organizationCode: string;
+  propertyCode: string;
+  jurisdictionCode: string;
+  languageCode: string;
+  identities: ProfilePreferencesIdentity[];
+  context: ProfilePreferencesContext;
+  controllerCode?: string;
+  environmentCode?: string;
+  attributes?: ProfilePreferencesAttribute[];
+  accountId?: string;
+  regionCode?: string;
+}
+
+/** ketch-types `GetSubscriptionsRequest` / `SetSubscriptionsRequest` */
+export interface SubscriptionsRequest {
+  organizationCode: string;
+  controllerCode?: string;
+  propertyCode?: string;
+  environmentCode?: string;
+  identities?: Record<string, string>;
+  topics?: Record<string, Record<string, string>>;
+  controls?: Record<string, Record<string, string>>;
+  collectedAt?: number;
+  jurisdictionCode?: string;
+  regionCode?: string;
+}
+
+export type SubscriptionsResponse = SubscriptionsRequest;
+
+export interface SubscriptionConfigurationRequest {
+  organizationCode: string;
+  propertyCode: string;
+  languageCode: string;
+  experienceCode: string;
+}
+
+export interface PreferenceQRRequest {
+  organizationCode: string;
+  propertyCode: string;
+  environmentCode?: string;
+  imageSize?: number;
+  path?: string;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  parameters?: Record<string, string>;
+}
+
+export interface WebReportRequest {
+  type: string;
+  age: number;
+  url: string;
+  user_agent: string;
+  body: Record<string, string>;
+}

--- a/package/src/headless/index.ts
+++ b/package/src/headless/index.ts
@@ -1,0 +1,6 @@
+export {
+  HeadlessApiClient,
+  KetchHeadless,
+  type KetchHeadlessOptions,
+} from './headlessApiClient';
+export * from './headlessTypes';

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,6 +1,8 @@
 export * from './context';
 export * from './enums';
+export * from './headless';
 export * from './KetchServiceProvider';
 export * from './types';
 export * from './util';
+export * from './trackingAuthorization';
 export { default as NativeKetchModule } from './NativeKetchModule';


### PR DESCRIPTION
## Description of this change

headless/ module, Jest tests, example app dashboard.

Stacked on RN ATT (slice 3/3).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

headlessApiClient.test.ts, headlessCdnIntegration.test.ts, example app.

## Related issues

Refs partial stack replacing #119.

## Checklist
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New consent and profile/subscription HTTP paths affect privacy behavior; WebView URL hooking and example dev overrides are powerful but mostly sample/test scoped.
> 
> **Overview**
> Adds a **headless `web/v3` layer** (`KetchHeadless` / `HeadlessApiClient`) so apps can call location, config, consent get/update, profiles, subscriptions, rights, QR URLs, and reporting over native `fetch` without a WebView. Consent requests strip `protocols` on update; responses normalize empty/null bodies and fall back when the server returns no usable purposes or protocols.
> 
> The package **re-exports** the headless module and types from the public entrypoint. **WebView bootstrap** now reads init params from the injected object (not query round-trips), supports **`webResourceUrlOverrides`** via script/`fetch` hooks (including early `<head>` injection), and related **helper tests** cover `ketch_att` and UAT CDN URL mapping.
> 
> The **example app** gains a SDK health dashboard (callbacks → state + event log), iOS ATT controls, buttons to exercise headless CDN flows, optional localhost tag overrides, and updated default org/property/UAT settings. **Jest** adds broad `HeadlessApiClient` unit tests plus opt-in live CDN integration tests; iOS **CocoaPods** gems are bumped to 1.16 / ActiveSupport 7.2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit defab8e910b294c5477fe54caa5b0268152f2d68. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->