### PR TITLE
feat: add run-sample Cursor skills

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -1,0 +1,92 @@
+---
+alwaysApply: true
+---
+
+# Development Workflow — Ketch React Native SDK
+
+## Prerequisites
+
+- **Node.js** >= 18
+- **Yarn** 4.x (per `example/package.json` `packageManager`) or npm
+- **Android**: Android SDK, `adb`, emulator or device
+- **iOS** (macOS only): Xcode, CocoaPods (`pod`), iOS Simulator
+
+## Setup
+
+```bash
+git clone git@github.com:ketch-com/ketch-react-native.git
+cd ketch-react-native
+```
+
+To run the **in-repo example** (npm release or local `file:../package` — see skill):
+
+```bash
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android        # remote (default)
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android local # this checkout
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios local
+```
+
+## Common Commands
+
+| Command | Purpose |
+| --- | --- |
+| `cd package && npm run all` | Lint, typecheck, and build the library |
+| `cd package && npm test` | Run package unit tests |
+| `cd example && npm run start` | Start Metro bundler |
+| `cd example && npm run android` / `npm run ios` | Run example (Metro must be running) |
+| `bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android local` | Full flow: configure, Metro, build, launch, logs |
+| `cd example/ios && pod install` | Refresh iOS pods after native dependency changes |
+
+## Validation Checklist
+
+Before merging SDK changes:
+
+1. `cd package && npm run lint && npm run typecheck` — **must pass**
+2. `cd package && npm test` — **must pass**
+3. `bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android local --build-only` — example must build
+4. If iOS native code changed: `bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios local --build-only`
+
+## Testing
+
+- **Package tests**: Jest in `package/`
+- **Integration tests**: `KETCH_INTEGRATION_TESTS=1 npm run test:integration` in `package/`
+- **Example app**: manual verification via run-sample script or `npm run android` / `npm run ios`
+
+## Code Quality
+
+- Match existing **TypeScript** style under `package/src/`
+- Keep public API exports intentional in `package/src/index.ts`
+- Prefer **small, focused diffs**; do not reformat unrelated files
+
+## SDK Health Dashboard (manual QA)
+
+`example/` wires `KetchServiceProvider` callbacks in `App.tsx` into `DashboardContext`; `Main.tsx` renders structured panels above the existing controls.
+
+| Section | What to verify |
+| --- | --- |
+| **Connection** | Init, status, org/property/env (editable), data center |
+| **WebView / Experience** | Load, visibility, dismiss, WebView visibility; `ketch_att` on iOS |
+| **ATT (iOS)** | Native ATT; **Request ATT** then **Reload WebView** |
+| **Privacy / Consent** | Environment, jurisdiction, region, consent, US Privacy / TCF / GPP |
+| **Headless** | Fetch Location / Bootstrap / Cold Start (`useKetchService()` headless APIs) |
+| **Event log** | Timestamped callback trace |
+
+Launch: `bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios local`
+
+Example org/property: `ethansch061226` / `website_smart_tag`. See `ketch-react-native-run-sample` skill for prerequisites, launch, and smoke flow.
+
+Provider uses `autoLoad={false}` so **Load** is an explicit manual step.
+
+## Local tag URL overrides (non-prod scripts)
+
+Pass `webResourceUrlOverrides` on `KetchServiceProvider` / `KetchMobile` — exact source URL → local replacement. Separate from `dataCenter` (boot.js base).
+
+```tsx
+<KetchServiceProvider
+  webResourceUrlOverrides={{
+    'https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js': 'http://localhost:9000/ketch-sdk.js',
+  }}
+/>
+```
+
+JS hook in `package/src/assets/index.ts` runs before boot.js. Sample: `DEV_URL_OVERRIDES_ENABLED = true` in `example/devUrlOverrides.ts`.

--- a/.cursor/skills/ketch-react-native-run-sample/SKILL.md
+++ b/.cursor/skills/ketch-react-native-run-sample/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: ketch-react-native-run-sample
+description: Configures the in-repo React Native example for either the released @ketch-com/ketch-react-native npm package or the local file:../package link, starts Metro, builds, launches on android or ios, and streams filtered logs. Use when the user runs /ketch-react-native-run-sample.
+---
+
+# ketch-react-native-run-sample
+
+## Instructions
+
+When the user invokes **`/ketch-react-native-run-sample`** (or asks to run the RN example with production / local SDK):
+
+1. `cd` to the `ketch-react-native` repository root.
+
+2. Run the helper script with a **required** platform argument:
+
+**Released package (default)** — rewrites `example/package.json` to use npm. Fetches the **latest version** via `npm view` unless `KETCH_RN_VERSION` is set.
+
+```bash
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios
+```
+
+**Local package** — uses `file:../package`:
+
+```bash
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android local
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios local
+```
+
+The script installs dependencies, starts Metro if needed, runs `pod install` on iOS when the dependency changes, launches via `react-native run-*`, and streams logs. Stop with `Ctrl-C`.
+
+## Manual testing basics
+
+**Needs:** Node + yarn (or npm), Metro (started by script), Android emulator + `adb` or iOS Simulator + Xcode/CocoaPods, network for CDN/headless steps.
+
+**Launch:** `bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios local` or `... android local` from the `ketch-react-native` repo root.
+
+**In the app:** **SDK Health Dashboard** is the first section in the example scroll view. Provider defaults: org `ethansch061226`, property `website_smart_tag`. Provider uses `autoLoad={false}` — tap **Load** explicitly.
+
+**Smoke flow:** **Load** → dashboard rows update → **Show Consent** → WebView/Experience rows change → (iOS) **Request ATT** then **Reload WebView** → Headless **Fetch Bootstrap**.
+
+## Overrides
+
+```bash
+KETCH_RN_VERSION=0.6.9 bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android
+DEVICE_ID=emulator-5554 bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android local
+SIMULATOR_NAME="iPhone 15 Pro" bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios local
+```
+
+## Other options
+
+```bash
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android local --build-only
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh ios --full-system-logs
+bash .cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh android --no-logs
+```
+
+## Manual QA checklist (SDK Health Dashboard)
+
+After launch, verify on-screen panels in `example/Main.tsx` (SDK Health Dashboard section):
+
+1. **Connection** — Init/status; org/property/env from editable fields; data center from API Region.
+2. **Load** — Tap **Load** → Load row `loading`; status updates; provider callbacks fill privacy rows.
+3. **WebView / Experience** — **Show Consent** → visibility/dismiss/WebView rows update via `App.tsx` callbacks.
+4. **ATT (iOS)** — **Request ATT** then **Reload WebView**; `ketch_att` row updates.
+5. **Headless** — **Fetch Location** / **Fetch Bootstrap** / **Cold Start** show inline results.
+6. **Event log** — Timestamped callback trace at bottom of dashboard section.
+
+Provider uses `autoLoad={false}` — **Load** is explicit.
+
+## Notes
+
+- Default remote mode needs **network access** for `npm view` when not pinning with `KETCH_RN_VERSION`.
+- **iOS** requires CocoaPods (`pod`) and Xcode; **Android** requires `adb`.
+- Example uses `packageManager: yarn@4.2.2`; script prefers **yarn** when available.

--- a/.cursor/skills/ketch-react-native-run-sample/scripts/configure-sample-package.py
+++ b/.cursor/skills/ketch-react-native-run-sample/scripts/configure-sample-package.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Switch example/package.json between local file: dependency and npm registry release."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PACKAGE_NAME = "@ketch-com/ketch-react-native"
+LOCAL_SPEC = "file:../package"
+LOCAL_RE = re.compile(
+    rf'"{re.escape(PACKAGE_NAME)}":\s*"file:\.\./package"'
+)
+REMOTE_RE = re.compile(
+    rf'"{re.escape(PACKAGE_NAME)}":\s*"[\^~]?\d+\.\d+\.\d+(?:-[\w.]+)?"'
+)
+
+
+def latest_npm_version() -> str:
+    proc = subprocess.run(
+        ["npm", "view", PACKAGE_NAME, "version"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise SystemExit(
+            f"npm view failed ({proc.returncode}) for {PACKAGE_NAME!r}:\n{proc.stderr.strip()}"
+        )
+    version = proc.stdout.strip()
+    if not version:
+        raise SystemExit(f"No version returned for {PACKAGE_NAME!r}")
+    return version
+
+
+def remote_version() -> tuple[str, str]:
+    pinned = os.environ.get("KETCH_RN_VERSION", "").strip()
+    if pinned:
+        return pinned, f"exactVersion={pinned!r}"
+    version = latest_npm_version()
+    return version, f"{version!r} (latest on npm)"
+
+
+def target_spec(mode: str) -> tuple[str, str]:
+    if mode == "local":
+        return LOCAL_SPEC, "local file:../package"
+    version, summary = remote_version()
+    return version, f"npm ({summary})"
+
+
+def replace_dependency_text(content: str, new_spec: str) -> str:
+    replacement = f'"{PACKAGE_NAME}": "{new_spec}"'
+    if LOCAL_RE.search(content):
+        return LOCAL_RE.sub(replacement, content, count=1)
+    if REMOTE_RE.search(content):
+        return REMOTE_RE.sub(replacement, content, count=1)
+    raise SystemExit(
+        f"No {PACKAGE_NAME} dependency found in package.json "
+        '(expected "file:../package" or a semver version).'
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit(
+            "Usage: configure-sample-package.py <local|remote> <path-to-package.json>"
+        )
+
+    mode = sys.argv[1]
+    package_path = Path(sys.argv[2])
+
+    if mode not in ("local", "remote"):
+        raise SystemExit("mode must be local or remote")
+    if not package_path.is_file():
+        raise SystemExit(f"Missing package.json: {package_path}")
+
+    new_spec, summary = target_spec(mode)
+    original = package_path.read_text(encoding="utf-8")
+    updated = replace_dependency_text(original, new_spec)
+
+    if updated != original:
+        package_path.write_text(updated, encoding="utf-8")
+        print(f"Updated {package_path} to use {summary}.")
+    else:
+        print(f"No changes needed for {package_path} ({mode}).")
+
+
+if __name__ == "__main__":
+    main()

--- a/.cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh
+++ b/.cursor/skills/ketch-react-native-run-sample/scripts/run-sample-app.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: run-sample-app.sh <android|ios> [local] [--build-only] [--no-logs] [--full-system-logs]
+
+  android|ios          Required. Target platform.
+  (no local)           Use the released @ketch-com/ketch-react-native from npm (latest version).
+  local                Link the example to file:../package in this repo.
+
+Options:
+  --build-only         Build and install without streaming logs afterward.
+  --no-logs            Skip post-launch log streaming.
+  --full-system-logs   Stream unfiltered logs (Android logcat / iOS process logs).
+
+Environment:
+  DEVICE_ID             Android device serial for react-native run-android.
+  SIMULATOR_NAME        iOS simulator name for react-native run-ios.
+  METRO_PORT            Metro port (default: 8081).
+  KETCH_RN_VERSION      Pin remote npm version (no registry lookup).
+
+Starts Metro when not already reachable, installs deps, runs pod install on iOS when needed.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+PLATFORM="$1"
+shift
+
+case "$PLATFORM" in
+  android|ios) ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "First argument must be android or ios, got: $PLATFORM" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+PACKAGE_MODE="remote"
+if [[ "${1:-}" == "local" ]]; then
+  PACKAGE_MODE="local"
+  shift
+fi
+
+build_only=0
+stream_logs=1
+full_system_logs=0
+METRO_PORT="${METRO_PORT:-8081}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --build-only)
+      build_only=1
+      shift
+      ;;
+    --no-logs)
+      stream_logs=0
+      shift
+      ;;
+    --full-system-logs)
+      full_system_logs=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_command python3
+require_command node
+require_command npm
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+EXAMPLE_DIR="$REPO_ROOT/example"
+PACKAGE_JSON="$EXAMPLE_DIR/package.json"
+IOS_BUNDLE_ID="org.reactjs.native.example.example"
+ANDROID_APP_ID="com.example"
+
+if [[ ! -f "$PACKAGE_JSON" ]]; then
+  echo "Example package.json not found: $PACKAGE_JSON" >&2
+  exit 1
+fi
+
+if [[ "$PLATFORM" == "ios" ]]; then
+  require_command xcrun
+fi
+if [[ "$PLATFORM" == "android" ]]; then
+  require_command adb
+fi
+
+CONFIGURE_OUTPUT="$(python3 "$SCRIPT_DIR/configure-sample-package.py" "$PACKAGE_MODE" "$PACKAGE_JSON")"
+echo "$CONFIGURE_OUTPUT"
+DEPENDENCY_CHANGED=0
+if echo "$CONFIGURE_OUTPUT" | grep -q "^Updated "; then
+  DEPENDENCY_CHANGED=1
+fi
+
+install_deps() {
+  cd "$EXAMPLE_DIR"
+  if grep -q '"packageManager".*yarn' package.json 2>/dev/null && command -v yarn >/dev/null 2>&1; then
+    echo "Installing dependencies with yarn..."
+    yarn install
+  else
+    echo "Installing dependencies with npm..."
+    npm install
+  fi
+}
+
+metro_running() {
+  curl -sf "http://localhost:${METRO_PORT}/status" >/dev/null 2>&1
+}
+
+start_metro() {
+  if metro_running; then
+    echo "Metro already running on port $METRO_PORT"
+    return
+  fi
+
+  echo "Starting Metro on port $METRO_PORT..."
+  cd "$EXAMPLE_DIR"
+  if grep -q '"packageManager".*yarn' package.json 2>/dev/null && command -v yarn >/dev/null 2>&1; then
+    yarn start --port "$METRO_PORT" --reset-cache >/dev/null 2>&1 &
+  else
+    npm run start -- --port "$METRO_PORT" >/dev/null 2>&1 &
+  fi
+  METRO_PID=$!
+
+  for _ in $(seq 1 30); do
+    if metro_running; then
+      echo "Metro ready."
+      return
+    fi
+    sleep 1
+  done
+
+  echo "Metro failed to start on port $METRO_PORT" >&2
+  kill "$METRO_PID" >/dev/null 2>&1 || true
+  exit 1
+}
+
+metro_pid=""
+log_pid=""
+cleanup() {
+  if [[ -n "$log_pid" ]] && kill -0 "$log_pid" >/dev/null 2>&1; then
+    kill "$log_pid" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+install_deps
+
+if [[ "$PLATFORM" == "ios" ]]; then
+  if [[ "$DEPENDENCY_CHANGED" -eq 1 ]] || [[ ! -d "$EXAMPLE_DIR/ios/Pods" ]]; then
+    echo "Running pod install..."
+    cd "$EXAMPLE_DIR/ios"
+    pod install
+  fi
+fi
+
+start_metro
+if [[ -n "${METRO_PID:-}" ]]; then
+  metro_pid="$METRO_PID"
+fi
+
+cd "$EXAMPLE_DIR"
+
+RN_ARGS=()
+if [[ "$PLATFORM" == "android" && -n "${DEVICE_ID:-}" ]]; then
+  RN_ARGS+=(--deviceId "$DEVICE_ID")
+fi
+if [[ "$PLATFORM" == "ios" && -n "${SIMULATOR_NAME:-}" ]]; then
+  RN_ARGS+=(--simulator "$SIMULATOR_NAME")
+fi
+
+if [[ "$PACKAGE_MODE" == "local" ]]; then
+  echo "Running example using local @ketch-com/ketch-react-native at $REPO_ROOT/package"
+else
+  echo "Running example using remote @ketch-com/ketch-react-native from npm (KETCH_RN_VERSION or latest)"
+fi
+
+if [[ "$build_only" -eq 1 ]]; then
+  RN_ARGS+=(--no-packager)
+elif metro_running; then
+  RN_ARGS+=(--no-packager --port "$METRO_PORT")
+fi
+
+echo "Building and launching on $PLATFORM..."
+if [[ "$PLATFORM" == "android" ]]; then
+  npx react-native run-android ${RN_ARGS+"${RN_ARGS[@]}"}
+else
+  npx react-native run-ios ${RN_ARGS+"${RN_ARGS[@]}"}
+fi
+
+if [[ "$build_only" -eq 1 ]]; then
+  echo "Build/install/launch complete (--build-only)."
+  exit 0
+fi
+
+if [[ "$stream_logs" -eq 0 ]]; then
+  echo "Skipping log stream (--no-logs)."
+  exit 0
+fi
+
+if [[ "$PLATFORM" == "android" ]]; then
+  device="${DEVICE_ID:-$(adb devices | awk 'NR > 1 && $2 == "device" { print $1; exit }')}"
+  if [[ -z "$device" ]]; then
+    echo "No adb device for log streaming." >&2
+    exit 0
+  fi
+  adb -s "$device" logcat -c >/dev/null 2>&1 || true
+  if [[ "$full_system_logs" -eq 1 ]]; then
+    echo "Streaming logcat (full). Press Ctrl-C to stop."
+    adb -s "$device" logcat -v brief
+  else
+    echo "Streaming logcat (ReactNativeJS + Ketch). Press Ctrl-C to stop."
+    adb -s "$device" logcat -v brief ReactNativeJS:V ReactNative:V "$ANDROID_APP_ID":V "*:S"
+  fi
+else
+  booted_id="$(xcrun simctl list devices booted | awk -F '[()]' '/Booted/ { print $2; exit }')"
+  if [[ -z "$booted_id" ]]; then
+    echo "No booted iOS simulator for log streaming." >&2
+    exit 0
+  fi
+  if [[ "$full_system_logs" -eq 1 ]]; then
+    predicate='process == "example"'
+    echo "Streaming unified logs for process example (full). Press Ctrl-C to stop."
+  else
+    predicate='process == "example" AND (eventMessage CONTAINS "Ketch" OR eventMessage CONTAINS "ketch")'
+    echo "Streaming unified logs filtered to Ketch messages. Press Ctrl-C to stop."
+  fi
+  xcrun simctl spawn "$booted_id" log stream \
+    --level debug \
+    --style compact \
+    --predicate "$predicate"
+fi


### PR DESCRIPTION
## Description of this change

Cursor skills and development-workflow rule documenting SDK Health Dashboard smoke flow (Load → Consent → ATT → Headless) with run scripts.

Independent PR off main (not stacked on SDK feature branches).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Docs/scripts only — verify run-sample-app.sh executes against sample app.

## Related issues

N/A — DX tooling.

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and helper scripts only; no SDK or example app runtime code changes, aside from optional `package.json` rewrites when running the configure script.
> 
> **Overview**
> Adds **Cursor DX tooling** so agents and contributors can run the in-repo React Native example against either the published `@ketch-com/ketch-react-native` package or `file:../package`, with documented validation and manual QA.
> 
> A new **always-on workflow rule** (`.cursor/rules/development-workflow.mdc`) documents prerequisites, common commands, a pre-merge validation checklist (including `run-sample-app.sh … --build-only`), and **SDK Health Dashboard** smoke steps plus optional `webResourceUrlOverrides` notes.
> 
> The **`ketch-react-native-run-sample` skill** describes invoking `/ketch-react-native-run-sample`, platform/`local` modes, env overrides (`KETCH_RN_VERSION`, `DEVICE_ID`, `SIMULATOR_NAME`), and dashboard QA.
> 
> **Scripts:** `configure-sample-package.py` rewrites `example/package.json` between local and npm (latest via `npm view` or pinned version). `run-sample-app.sh` orchestrates configure, install, Metro startup, conditional `pod install`, `react-native run-android`/`run-ios`, and filtered log streaming (`--build-only`, `--no-logs`, `--full-system-logs`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89148de07889c59a5724ca50b05681851c4bb08. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->