### PR TITLE
fix: lint

### DIFF
--- a/package/src/KetchServiceProvider/KetchServiceProvider.tsx
+++ b/package/src/KetchServiceProvider/KetchServiceProvider.tsx
@@ -39,7 +39,11 @@ import {
 
 import { KetchServiceContext } from '../context';
 import { Action, reducer } from './reducer';
-import { createOptionsString, getWebViewConfigKey, savePrivacyToStorage } from '../util';
+import {
+  createOptionsString,
+  getWebViewConfigKey,
+  savePrivacyToStorage,
+} from '../util';
 import { getIndexHtml, injectCssIntoHtml } from '../assets';
 import styles from './styles';
 import nativeStorage from '../util/nativeStorage';
@@ -204,7 +208,7 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
     const resolveAtt = async () => {
       const attPrev =
         Platform.OS === 'ios'
-          ? (await nativeStorage.read(ATT_LAST_STORAGE_KEY) || 'notDetermined')
+          ? (await nativeStorage.read(ATT_LAST_STORAGE_KEY)) || 'notDetermined'
           : undefined;
 
       if (parameters.ketchAtt) {

--- a/package/src/util/nativeStorage.ts
+++ b/package/src/util/nativeStorage.ts
@@ -10,7 +10,7 @@ const nativeStorage = {
     crossPlatformSave(key, value),
 
   remove: async (key: string): Promise<void> => {
-    if (!!NativeModules.RNDefaultPreference) {
+    if (NativeModules.RNDefaultPreference) {
       try {
         const p = require('react-native-default-preference').default;
         await p.clear(key);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> lint fixes for previous pr

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic lint fixes only; no logic or security-sensitive changes.
> 
> **Overview**
> **Lint-only cleanup** with no intended behavior changes.
> 
> In `KetchServiceProvider`, the `../util` import is split across multiple lines, and the iOS ATT fallback expression is parenthesized so `|| 'notDetermined'` applies to the `await nativeStorage.read(...)` result (satisfies operator-precedence / formatting rules).
> 
> In `nativeStorage.remove`, the `RNDefaultPreference` guard drops redundant `!!` and uses a direct truthiness check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f08049aa69f99f310d4fe885c7b7a554c0abe112. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->