### PR TITLE
fix(KetchServiceProvider): Re-read ATT status and ketch_att_last on every load()

### DIFF
--- a/package/src/KetchServiceProvider/KetchServiceProvider.tsx
+++ b/package/src/KetchServiceProvider/KetchServiceProvider.tsx
@@ -241,7 +241,7 @@ export const KetchServiceProvider: React.FC<KetchServiceProviderParams> = ({
     return () => {
       cancelled = true;
     };
-  }, [parameters.ketchAtt]);
+  }, [parameters.ketchAtt, webViewReloadNonce]);
 
   /**
    * Load or reload the webview


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> The `resolveAtt` effect had `[parameters.ketchAtt]` as its only dependency. `ketch.load()` bumps `webViewReloadNonce` but did not re-trigger ATT resolution — the effect only ran once at app startup.

**Result:** The WebView always received the ATT status from startup. The tag received a stale `notDetermined`, wrote `ketch_att_last=notDetermined` on every load, creating a cycle where `ketch_att_prev` was perpetually `notDetermined`. The signal-notice banner only appeared after quit/reopen, never on the same launch as the ATT change.

**Fix:** Add `webViewReloadNonce` to the `resolveAtt` dep array (one line). Every `load()` call now re-reads live ATT status + `ketch_att_last` from storage before remounting the WebView.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified on iOS simulator using a throwaway ATT test harness. Confirmed: deny → banner renders on same launch, \`ketch_att_prev\` correctly reflects prior status.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

[KD-17455](https://ketch-com.atlassian.net/browse/KD-17455)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.


[KD-17455]: https://ketch-com.atlassian.net/browse/KD-17455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency-array change on iOS ATT resolution; behavior aligns with existing reload/remount flow with no new APIs or security surface.
> 
> **Overview**
> Fixes stale App Tracking Transparency (ATT) values passed into the Ketch WebView when **`ketch.load()`** remounts the view.
> 
> The iOS **`resolveAtt`** effect previously depended only on **`parameters.ketchAtt`**, so it ran once at startup. **`load()`** increments **`webViewReloadNonce`** to force a remount (avoiding Android **`reload()`** parameter loss), but ATT and **`ketch_att_last`** were not re-read before that remount. The tag could keep seeing startup **`notDetermined`**, overwrite storage, and leave **`ketch_att_prev`** stuck—so the signal-notice banner often only appeared after a full app restart.
> 
> **Change:** add **`webViewReloadNonce`** to the effect dependency array so each reload path re-resolves live ATT status and the stored previous value before the WebView mounts again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6b87b387e653df27a6f1070853268c2b60896b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->