### PR TITLE
fix: [KD-17979] replace absoluteFillObject for RN 0.85 WebView overlay

### DIFF
--- a/package/__tests__/styles.test.ts
+++ b/package/__tests__/styles.test.ts
@@ -1,0 +1,39 @@
+import { StyleSheet } from 'react-native';
+
+import styles from '../src/KetchServiceProvider/styles';
+
+describe('KetchServiceProvider styles', () => {
+  it('positions the WebView overlay full-screen without absoluteFillObject', () => {
+    const container = StyleSheet.flatten(styles.container);
+
+    expect(container).toMatchObject({
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      top: 0,
+      bottom: 0,
+      backgroundColor: 'transparent',
+      zIndex: 99999,
+    });
+  });
+
+  it('still fills the screen when StyleSheet.absoluteFillObject is removed (RN 0.85)', () => {
+    const legacySpread = {
+      ...(undefined as typeof StyleSheet.absoluteFillObject),
+      backgroundColor: 'transparent',
+      zIndex: 99999,
+    };
+
+    expect(StyleSheet.flatten(legacySpread)).not.toMatchObject({
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+    });
+
+    expect(StyleSheet.flatten(styles.container)).toMatchObject({
+      position: 'absolute',
+      top: 0,
+      bottom: 0,
+    });
+  });
+});

--- a/package/__tests__/styles.test.ts
+++ b/package/__tests__/styles.test.ts
@@ -19,7 +19,6 @@ describe('KetchServiceProvider styles', () => {
 
   it('still fills the screen when StyleSheet.absoluteFillObject is removed (RN 0.85)', () => {
     const legacySpread = {
-      ...(undefined as typeof StyleSheet.absoluteFillObject),
       backgroundColor: 'transparent',
       zIndex: 99999,
     };

--- a/package/src/KetchServiceProvider/styles.ts
+++ b/package/src/KetchServiceProvider/styles.ts
@@ -2,7 +2,11 @@ import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
   container: {
-    ...StyleSheet.absoluteFillObject,
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
     backgroundColor: 'transparent',
     zIndex: 99999,
   },


### PR DESCRIPTION
## Description of this change

> React Native 0.85 removed `StyleSheet.absoluteFillObject`. The Ketch WebView overlay container in `KetchServiceProvider` spread that API for full-screen positioning, so on RN 0.85+ the spread is a no-op and `showPreferenceExperience` / `showConsentExperience` can appear not to render. Replaced it with explicit absolute inset styles (`position`, `top`, `left`, `right`, `bottom`) and added unit tests that assert the layout and simulate the removed API.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

- `cd package && npm test` — 6/6 Jest tests pass, including new `styles.test.ts` coverage for full-screen container layout and RN 0.85 `absoluteFillObject` removal simulation.
- iOS example app (`run-sample-app.sh ios local` on iPhone 17 Pro): **Reload** → **Preferences** and **Consent** — WebView overlay covers the full screen.

Reviewer can repeat with the example app linked to `file:../package` on this branch.

## Related issues

Jira: https://ketch-com.atlassian.net/browse/KD-17979

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized styling change with unit tests; no auth, data, or API behavior changes.
> 
> **Overview**
> **Fixes full-screen Ketch consent/preference WebView overlays on React Native 0.85+**, where `StyleSheet.absoluteFillObject` was removed so spreading it into `KetchServiceProvider` container styles no longer applied inset positioning.
> 
> The overlay `container` style now uses explicit `position: 'absolute'` with `top`/`left`/`right`/`bottom: 0` instead of `...StyleSheet.absoluteFillObject`. New Jest tests in `styles.test.ts` lock in the expected layout and document the regression when the old spread is a no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e72ad98fc31976738d2fe91849b2a218f2745d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->