### PR TITLE
fix(deps): bump activesupport past the Rails 7.0 advisories

### DIFF
--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby ">= 2.6.10"
+ruby ">= 3.1.0"
 
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.
 gem 'cocoapods', '>= 1.13', '< 1.15'
-gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'activesupport', '>= 7.2.3.1', '< 8.0'
 gem 'addressable', '>= 2.9.0'

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -5,11 +5,18 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.0.8.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (7.2.3.2)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
-      minitest (>= 5.1)
-      tzinfo (~> 2.0)
+      logger (>= 1.4.2)
+      minitest (>= 5.1, < 6)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     algoliasearch (1.27.5)
@@ -17,6 +24,8 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.2)
     claide (1.1.0)
     cocoapods (1.14.3)
       addressable (~> 2.8)
@@ -56,7 +65,8 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.8)
+    connection_pool (3.0.2)
     drb (2.2.3)
     escape (0.0.4)
     ethon (0.16.0)
@@ -66,21 +76,20 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.14.4)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    minitest (6.0.6)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    logger (1.7.0)
+    minitest (5.27.0)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
-    prism (1.9.0)
     public_suffix (4.0.7)
     rexml (3.4.2)
     ruby-macho (2.5.1)
+    securerandom (0.4.1)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
@@ -97,7 +106,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 6.1.7.5, < 7.1.0)
+  activesupport (>= 7.2.3.1, < 8.0)
   addressable (>= 2.9.0)
   cocoapods (>= 1.13, < 1.15)
 


### PR DESCRIPTION
## Description of this change

Clears the three [Vulnerabilities 2026](https://ketch-com.atlassian.net/browse/KD-17795) `activesupport` advisories filed against this repo: KD-17855 (ReDoS in `number_to_delimited`), KD-17856 (XSS in `SafeBuffer#%`), KD-17857 (DoS in the number helpers). All three have the same fix line, 7.2.3.1, and all three clear on one bump.

`example/Gemfile` was pinned `>= 6.1.7.5, < 7.1.0`, resolving to 7.0.8.1. The fix line sits outside that cap and Rails did not backport these advisories to 7.0.x, so the cap had to move before anything else could.

That cap comes from the React Native app template, not from our code, and it is still present upstream — I checked `packages/helloworld/Gemfile` on both RN v0.79.0 (what `example/` uses) and v0.80.0, and both still carry `'>= 6.1.7.5', '< 7.1.0'`. So the question was whether the cap is actually load-bearing for us, or just inherited boilerplate.

**It is not load-bearing.** CocoaPods is the only consumer of activesupport here, and `cocoapods 1.14.3` declares `activesupport >= 5.0, < 8` — 7.2.3.2 is well inside its own supported range. I verified CocoaPods still starts and fully initializes on the bumped resolution (see testing below).

### What moved

| gem | before | after | why |
|---|---|---|---|
| activesupport | 7.0.8.1 | 7.2.3.2 | the fix; ≥ 7.2.3.1 target |
| concurrent-ruby | 1.2.3 | 1.3.8 | activesupport 7.2 needs `>= 1.3.1` |
| i18n | 1.14.4 | 1.15.2 | pulled along |
| minitest | 6.0.6 | 5.27.0 | **downgrade** — activesupport 7.2 constrains it to `>= 5.1, < 6` |
| benchmark, bigdecimal, connection_pool, logger, securerandom | — | added | new activesupport 7.2 runtime deps |
| prism | 1.9.0 | removed | was only there for minitest 6 |

The minitest downgrade is the one thing worth a reviewer's eye. It is not arbitrary — activesupport 7.2's gemspec caps minitest below 6. Nothing in this repo runs minitest; it is transitive via activesupport only.

### Ruby floor

`activesupport` 7.2.3.2 declares `required_ruby_version >= 3.1.0`, so I raised the Gemfile's `ruby` directive from `">= 2.6.10"` to `">= 3.1.0"` rather than leave a declaration the resolution can't honour.

This is a formality, not a new constraint on anyone: the committed `Gemfile.lock` already recorded `RUBY VERSION ruby 3.3.0p0` before this change. The `2.6.10` line was inherited template boilerplate that no longer described reality.

### Scope

This gem is example-app tooling. It is used by CocoaPods when building `example/` for local development and is not part of the published `@ketch-com/ketch-react-native` package — nothing consumers install pulls Ruby. So this is supply-chain hygiene on the dev workflow, not a fix to shipped SDK code.

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Ruby 3.3.12 (matching the `RUBY VERSION` already in the lockfile), bundler 2.5.4, in `example/`:

**Baseline first**, on unmodified `main`, to establish that the check is meaningful:
```
bundle install && bundle exec pod --version
# activesupport 7.0.8.1 -> CocoaPods 1.14.3   ✅
```

**After the bump:**
```
bundle install && bundle exec pod --version
# activesupport 7.2.3.2 -> CocoaPods 1.14.3   ✅
bundle exec pod env
# full CocoaPods stack initializes, reports 1.14.3 on Ruby 3.3.12   ✅
```

`pod env` is the meaningful check — it loads the entire CocoaPods stack, which is where an activesupport incompatibility would surface. It ran clean; the only complaint was `xcodebuild requires Xcode`, which is my machine lacking full Xcode and is unrelated to this change.

**What I could not verify:** an actual `pod install` against the example app's Podfile. That needs `example/node_modules` populated (private-registry auth) and full Xcode, neither of which I have here. Someone on a machine with Xcode should run `cd example && bundle install && bundle exec pod install` before merge to confirm end to end.

I also confirmed the lockfile diff is contained to the activesupport dependency chain — 20 insertions, 11 deletions, no unrelated gem churn. `BUNDLED WITH` is unchanged at 2.5.4.

No tests added: this changes no source code, only build tooling for the example app.

## Related issues

KD-17855, KD-17856, KD-17857

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only example Gemfile/lockfile changes with no SDK or runtime impact; main watch item is transitive minitest downgrade, which this repo does not run directly.
> 
> **Overview**
> Bumps **`activesupport`** in the example app’s CocoaPods **`Gemfile`** from the 7.0.x cap to **`>= 7.2.3.1, < 8.0`**, resolving **`7.2.3.2`** in the lockfile to clear three Rails 7.0 security advisories (ReDoS, XSS, DoS in number helpers).
> 
> The inherited **`activesupport < 7.1.0`** ceiling had to move because fixes were not backported to 7.0.x. The **`ruby`** directive is raised from **`>= 2.6.10`** to **`>= 3.1.0`** to match activesupport 7.2’s requirement; the lockfile already targeted Ruby 3.3. Transitive churn is limited to the activesupport chain (notably **minitest** capped back to 5.x). Scope is **example/** iOS build tooling only—not the published React Native package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883eee72acded297acc18d4f172a2a360fe2e764. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->