### PR TITLE
fix(deps): override @expo/metro-config's postcss to 8.5.25 for CVE-2026-41305

### DIFF
--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -13598,9 +13598,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -13608,6 +13608,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -14302,9 +14303,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -14320,9 +14321,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package/package.json
+++ b/package/package.json
@@ -84,7 +84,8 @@
   },
   "resolutions": {
     "@types/react": "^18.2.44",
-    "tmp": "^0.2.6"
+    "tmp": "^0.2.6",
+    "postcss": "^8.5.10"
   },
   "packageManager": "yarn@4.1.1",
   "jest": {

--- a/package/package.json
+++ b/package/package.json
@@ -168,6 +168,9 @@
     "form-data": "^4.0.4",
     "brace-expansion": "^2.0.2",
     "tmp": "^0.2.6",
-    "lodash": "^4.18.0"
+    "lodash": "^4.18.0",
+    "@expo/metro-config": {
+      "postcss": "^8.5.10"
+    }
   }
 }

--- a/package/yarn.lock
+++ b/package/yarn.lock
@@ -6061,10 +6061,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.7:
-  version "3.3.11"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+nanoid@^3.3.16:
+  version "3.3.16"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz"
+  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -6542,12 +6542,12 @@ pngjs@^3.3.0:
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
 
-postcss@~8.4.32:
-  version "8.4.49"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz"
-  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
+postcss@^8.5.10:
+  version "8.5.25"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz"
+  integrity sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==
   dependencies:
-    nanoid "^3.3.7"
+    nanoid "^3.3.16"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Description of this change

Clears the ketch-react-native half of KD-17887 (CVE-2026-41305, PostCSS XSS via unescaped `</style>` in CSS stringify output). The ticket was closed as Done but Vanta still reports it, because this repo was never actually fixed — only porthole and transponder were.

`postcss` resolved to **8.4.49** in `package/`, a dev-only transitive of `@expo/metro-config`, which declares `postcss ~8.4.32`. That tilde caps the range at `<8.5.0`, so the 8.5.10 fix is unreachable by any plain `npm update` — this needed an override.

Scoped to the one parent rather than a blanket `"postcss": "^8.5.10"`, so nothing else in the tree gets silently retargeted:

```json
"overrides": {
  "@expo/metro-config": { "postcss": "^8.5.10" }
}
```

`postcss` now resolves to **8.5.25**. Lockfile delta is two entries:

| entry | before | after |
|---|---|---|
| `node_modules/postcss` | 8.4.49 | **8.5.25** |
| `node_modules/nanoid` | 3.3.11 | 3.3.16 (postcss's own dep) |

### Why yarn.lock is also touched

`package/` carries both `package-lock.json` and `yarn.lock`. CI installs with `npm ci --ignore-scripts`, so package-lock is authoritative for builds — but Snyk/Vanta read whatever lockfiles are present, so leaving `yarn.lock` pinned at 8.4.49 would have left the finding open. Both are updated to 8.5.25.

The yarn.lock diff is larger than the npm one (+63 lines) and worth understanding before you read it as churn. Removals are only the two `postcss@~8.4.32` / `nanoid@^3.3.7` blocks being replaced. The additions are 9 `lightningcss-*` platform binaries that were previously absent — the committed yarn.lock only had `lightningcss-darwin-arm64`, i.e. it had been generated on an Apple Silicon mac. npm's resolution filled in the other platforms. They're optionalDependencies, so a given install still fetches only its own platform. Additive, and arguably more correct than before, but flagging it so nobody has to guess.

### Update: yarn needed its own entry (Bugbot catch)

The npm `overrides` entry alone was not enough. Yarn ignores `overrides` and reads `resolutions`, so the `postcss@^8.5.10` line in `yarn.lock` was orphaned — `@expo/metro-config` still requests `~8.4.32`, and a fresh `yarn install` would have re-resolved postcss to a vulnerable 8.4.x.

Added `postcss` to the **existing** `resolutions` block, which this repo already uses for `@types/react` and `tmp`:

```json
"resolutions": {
  "@types/react": "^18.2.44",
  "tmp": "^0.2.6",
  "postcss": "^8.5.10"
}
```

Both mechanisms are now present: `overrides` for npm (what CI uses) and `resolutions` for yarn.

## Why is this change being made?
- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Node 22.23.1 / npm 10.9.8, in `package/`, installing the same way CI does:

- `npm install --package-lock-only` — verified the package-lock delta is only the two entries above
- `npm ci --ignore-scripts --no-audit --no-fund` — clean, 1425 packages
- `require('postcss/package.json').version` → **8.5.25**
- `npm run typecheck` (`tsc --noEmit`) — **passes**
- `npm run lint` (`eslint "**/*.{js,ts,tsx}"`) — **passes**, no warnings
- `npm test` (`jest`) — **passes**, 2 suites / 6 tests

Reviewer can confirm with:
```
cd package && npm ci --ignore-scripts && npm run typecheck && npm run lint && npm test
node -e "console.log(require('postcss/package.json').version)"   # 8.5.25
```

Jest prints a "worker process failed to exit gracefully" warning after the suites pass. That is pre-existing teardown noise in the existing tests, not related to this change — all 6 tests pass.

Yarn side, verified after adding the resolution — ran a real `yarn install` against a scratch copy of `package.json` + `yarn.lock`:

- exactly **one** postcss entry remains in the lockfile (`postcss@^8.5.10` -> 8.5.25)
- **no** 8.4.x version anywhere; yarn did not revert the entry
- re-ran `npm install --package-lock-only` afterwards to confirm the npm side is untouched (postcss still 8.5.25)

The scratch copy was necessary because `package.json` declares `packageManager: yarn@4.1.1` while the committed `yarn.lock` is in **yarn v1 format** (`# yarn lockfile v1`). Yarn 1 refuses to run against that field, and invoking Yarn 4 would rewrite the entire lockfile into Berry format — far more churn than this fix warrants. That mismatch is pre-existing and worth its own cleanup.

No tests added: dependency-only change with no source modifications.

## Related issues

KD-17887

## Checklist
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only security patch in dev tooling (Metro/PostCSS); no runtime or auth/data-path changes.
> 
> **Overview**
> Addresses **CVE-2026-41305** (PostCSS XSS via unescaped `</style>` in stringify output) for the ketch-react-native package by forcing a patched PostCSS version that `@expo/metro-config` cannot reach on its own (`~8.4.32` caps below 8.5.x).
> 
> Adds an **`overrides`** entry scoped to `@expo/metro-config` only (`postcss: ^8.5.10`), avoiding a global PostCSS retarget for the rest of the tree. Lockfiles (`package-lock.json` and `yarn.lock`) now resolve **`postcss` 8.4.49 → 8.5.25** and bump **`nanoid`** to 3.3.16 as PostCSS’s dependency. No application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c2a8f9f97a5349f865a69ad23a2a439636e410. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
