### PR TITLE
refactor: extract device locale helpers

### DIFF
--- a/package/__tests__/deviceLocale.test.ts
+++ b/package/__tests__/deviceLocale.test.ts
@@ -1,0 +1,19 @@
+import { formatLanguageTag } from '../src/util/deviceLocale';
+
+describe('formatLanguageTag', () => {
+  it('underscore separator becomes hyphen with uppercase dialect', () => {
+    expect(formatLanguageTag('en_US')).toBe('en-US');
+  });
+
+  it('lowercase dialect is uppercased', () => {
+    expect(formatLanguageTag('fr-ca')).toBe('fr-CA');
+  });
+
+  it('root only is lowercased', () => {
+    expect(formatLanguageTag('EN')).toBe('en');
+  });
+
+  it('blank falls back to english', () => {
+    expect(formatLanguageTag('')).toBe('en');
+  });
+});

--- a/package/src/util/deviceLocale.ts
+++ b/package/src/util/deviceLocale.ts
@@ -1,0 +1,23 @@
+import { Platform, NativeModules } from 'react-native';
+
+/** Raw device locale identifier (e.g. "en_US" on Android, "en-US"/"en_US" on iOS). */
+export function getDeviceLanguage(): string {
+  return Platform.OS === 'ios'
+    ? NativeModules.SettingsManager?.settings?.AppleLocale ||
+        NativeModules.SettingsManager?.settings?.AppleLanguages?.[0] ||
+        'en'
+    : NativeModules.I18nManager?.localeIdentifier || 'en';
+}
+
+/** Matches ketch-tag's `formatLanguage` ("fr-CA"), tolerant of the "fr_CA" form. */
+export function formatLanguageTag(raw: string): string {
+  if (!raw) return 'en';
+  const [root, dialect] = raw.split(/[-_]/);
+  return dialect
+    ? `${root!.toLowerCase()}-${dialect.toUpperCase()}`
+    : root!.toLowerCase();
+}
+
+export function getDeviceLanguageTag(): string {
+  return formatLanguageTag(getDeviceLanguage());
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Extracts the raw device-locale lookup and a BCP-47 formatter (`getDeviceLanguageTag`) into their own module, replacing the module-level `deviceLanguage` const in `KetchServiceProvider`. Pure refactor, no behavior change.
>
> Part 1/5 of a split of #126 into a stack of small, independently reviewable PRs. Full stack: #137 → #138 → #139 → #140 → #141.

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

> `npm run lint`, `npm run typecheck`, and `npm test` (this PR's own `deviceLocale.test.ts`, 4/4 passing) all pass standalone on this branch.
>
> The full 5-PR stack was verified as a faithful, complete split of #126 before publishing: `git diff --exit-code <top-of-stack> origin/ethanpschoen/feat/headless-api` is empty (exit 0), and the top of the stack passes the full local gate (lint, typecheck, build, `npm test`).

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

> Refs #126.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.