### PR TITLE
feat: add privacy string accessors

### DIFF
--- a/package/src/util/index.ts
+++ b/package/src/util/index.ts
@@ -1,5 +1,7 @@
 export * from './helpers';
 export * from './services';
 export * from './hooks';
+export * from './deviceLocale';
+export * from './privacyStrings';
 export { default as wrapSharedPreferences } from './wrapSharedPrefences';
 export { default as nativeStorage } from './nativeStorage';

--- a/package/src/util/privacyStrings.ts
+++ b/package/src/util/privacyStrings.ts
@@ -1,0 +1,29 @@
+import nativeStorage from './nativeStorage';
+
+/**
+ * Storage keys the ketch tag writes IAB privacy strings to. Names match the IAB
+ * specifications and the keys used by the Android and iOS SDKs.
+ */
+export const IAB_TCF_TC_STRING = 'IABTCF_TCString';
+export const IAB_US_PRIVACY_STRING = 'IABUSPrivacy_String';
+export const IAB_GPP_HDR_GPP_STRING = 'IABGPP_HDR_GppString';
+
+/**
+ * Read a value the tag wrote to native storage.
+ * Async, unlike the synchronous Android equivalent, because native storage access
+ * on React Native is asynchronous.
+ */
+export const getSavedString = (key: string): Promise<string> =>
+  nativeStorage.read(key);
+
+/** Retrieve the IABTCF_TCString value written by the tag. */
+export const getTCFTCString = (): Promise<string> =>
+  getSavedString(IAB_TCF_TC_STRING);
+
+/** Retrieve the IABUSPrivacy_String value written by the tag. */
+export const getUSPrivacyString = (): Promise<string> =>
+  getSavedString(IAB_US_PRIVACY_STRING);
+
+/** Retrieve the IABGPP_HDR_GppString value written by the tag. */
+export const getGPPHDRGppString = (): Promise<string> =>
+  getSavedString(IAB_GPP_HDR_GPP_STRING);

--- a/package/src/util/privacyStrings.ts
+++ b/package/src/util/privacyStrings.ts
@@ -8,22 +8,30 @@ export const IAB_TCF_TC_STRING = 'IABTCF_TCString';
 export const IAB_US_PRIVACY_STRING = 'IABUSPrivacy_String';
 export const IAB_GPP_HDR_GPP_STRING = 'IABGPP_HDR_GppString';
 
+/** Reads a single key from whichever backend the tag actually wrote it to. */
+export type PreferenceReader = (key: string) => Promise<string>;
+
 /**
- * Read a value the tag wrote to native storage.
+ * Read a value the tag wrote to storage. Defaults to native storage, but accepts
+ * a custom reader so callers whose provider is configured with a `preferenceStorage`
+ * backend can read from the same place the tag wrote to, instead of always falling
+ * back to native storage.
  * Async, unlike the synchronous Android equivalent, because native storage access
  * on React Native is asynchronous.
  */
-export const getSavedString = (key: string): Promise<string> =>
-  nativeStorage.read(key);
+export const getSavedString = (
+  key: string,
+  read: PreferenceReader = nativeStorage.read
+): Promise<string> => read(key);
 
 /** Retrieve the IABTCF_TCString value written by the tag. */
-export const getTCFTCString = (): Promise<string> =>
-  getSavedString(IAB_TCF_TC_STRING);
+export const getTCFTCString = (read?: PreferenceReader): Promise<string> =>
+  getSavedString(IAB_TCF_TC_STRING, read);
 
 /** Retrieve the IABUSPrivacy_String value written by the tag. */
-export const getUSPrivacyString = (): Promise<string> =>
-  getSavedString(IAB_US_PRIVACY_STRING);
+export const getUSPrivacyString = (read?: PreferenceReader): Promise<string> =>
+  getSavedString(IAB_US_PRIVACY_STRING, read);
 
 /** Retrieve the IABGPP_HDR_GppString value written by the tag. */
-export const getGPPHDRGppString = (): Promise<string> =>
-  getSavedString(IAB_GPP_HDR_GPP_STRING);
+export const getGPPHDRGppString = (read?: PreferenceReader): Promise<string> =>
+  getSavedString(IAB_GPP_HDR_GPP_STRING, read);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Adds accessors for the IAB privacy strings the tag writes to native storage: TCF TC string, US Privacy string, GPP header string, and a generic `getSavedString` helper.
>
> The util barrel export (`util/index.ts`) also picks up `./deviceLocale` from the PR below this one in the stack, since both additions land in the same import block.
>
> Part 2/5 of the split of #126. Full stack: #137 → #138 → #139 → #140 → #141.
>
> **Review finding fixed here:** *Getters miss preferenceStorage values* — `getSavedString` and the IAB helpers always read via `nativeStorage`, so they never saw values persisted through a custom `preferenceStorage` backend (required for Expo Android per the README). Fixed by accepting an optional reader parameter, defaulting to the existing `nativeStorage.read`. The provider wiring that builds a reader from the configured `preferenceStorage` and binds these accessors to it lands in #141.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

> `npm run lint` and `npm run typecheck` pass standalone on this branch. No dedicated unit tests exist for `privacyStrings.ts` on the source branch — the functions are thin wrappers around `nativeStorage`, exercised indirectly once the `KetchService` members are exposed in #141.
>
> The full 5-PR stack was verified as a faithful, complete split of #126 before publishing: `git diff --exit-code <top-of-stack> origin/ethanpschoen/feat/headless-api` is empty (exit 0), and the top of the stack passes the full local gate (lint, typecheck, build, `npm test`).

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

> Refs #126.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.